### PR TITLE
feat: conectar rutas nuevas en app.js con prefijo /api

### DIFF
--- a/src/app.js
+++ b/src/app.js
@@ -1,25 +1,44 @@
 import express from 'express';
 import cors from 'cors';
-import usersRouter from './routes/users.routes.js';
-import tasksRouter from './routes/tasks.routes.js';
 
-const app = express()
-app.use(cors())
-app.use(express.json())
-app.use(express.urlencoded({ extended: true }))
-const port = 3000
+// Se importan los archivos de rutas NUEVOS creados por Paulo en esta guía
+// userRoutes.js reemplaza a users.routes.js (los archivos viejos NO se borran)
+// taskRoutes.js reemplaza a tasks.routes.js
+import usersRouter from './routes/userRoutes.js';
+import tasksRouter from './routes/taskRoutes.js';
 
+// Se crea la instancia principal del servidor Express
+const app = express();
+
+// Se habilita CORS para que el frontend pueda hacer peticiones al backend
+// Sin esto el navegador bloquearía las peticiones con un error de origen cruzado
+app.use(cors());
+
+// Se configura el servidor para recibir cuerpos de petición en formato JSON
+// Necesario para leer req.body en los controladores (POST, PUT, PATCH)
+app.use(express.json());
+
+// Se configura para recibir datos enviados desde formularios HTML
+app.use(express.urlencoded({ extended: true }));
+
+const port = 3000;
+
+// Ruta raíz para verificar que el servidor está activo
 app.get('/', (req, res) => {
-  res
-  .status(200)
-  .json({
-    message: 'Hola, Bienvenido a mi servidor'
-  })
+    res.status(200).json({ message: 'Hola, Bienvenido a mi servidor' });
 });
 
-app.use('/tasks', tasksRouter)
-app.use('/users', usersRouter)
+// Se registran las rutas de usuarios bajo el prefijo /api/users
+// El router de Paulo define la parte final: /, /:id, /:userId/tasks, etc.
+// Ejemplo: GET http://localhost:3000/api/users
+app.use('/api/users', usersRouter);
 
+// Se registran las rutas de tareas bajo el prefijo /api/tasks
+// El router de Paulo define la parte final: /, /filter, /dashboard, /:id, etc.
+// Ejemplo: GET http://localhost:3000/api/tasks/filter
+app.use('/api/tasks', tasksRouter);
+
+// Se inicia el servidor en el puerto 3000
 app.listen(port, () => {
-  console.log(`Example app listening on port ${port}`)
-})
+    console.log(`Servidor escuchando en el puerto ${port}`);
+});


### PR DESCRIPTION
Qué se hizo:
- Se modificó app.js para importar userRoutes.js y taskRoutes.js (archivos de Paulo)
- Se cambiaron los prefijos de /users y /tasks a /api/users y /api/tasks

Por qué:
El prefijo /api es la convención REST para identificar endpoints.
El frontend hace peticiones a /api/users y /api/tasks.
Sin este cambio el frontend no se conecta con el backend.

Archivos modificados: src/app.js
