### PR TITLE
fix: corregir busqueda por documento, filtros de usuario y rendimiento de tabla admin

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -31,11 +31,13 @@ CREATE TABLE IF NOT EXISTS users (
 
 -- tabla de tareas
 -- assigned_users: arreglo de IDs guardado como JSON (sin FK externa)
+-- comment: campo opcional para que el usuario anote observaciones sobre la tarea
 CREATE TABLE IF NOT EXISTS tasks (
     id              INT          NOT NULL AUTO_INCREMENT,
     title           VARCHAR(200) NOT NULL,
     description     TEXT,
     status          VARCHAR(20)  NOT NULL DEFAULT 'pendiente',
+    comment         TEXT         NULL,
     assigned_users  JSON         NOT NULL DEFAULT (JSON_ARRAY()),
     created_ud      TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
     updated_up      TIMESTAMP DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,

--- a/src/controller/users.controller.js
+++ b/src/controller/users.controller.js
@@ -6,10 +6,11 @@
 
 import {
     getAllUsers,
-    getUserById    as findUserById,
-    createUser     as insertUser,
-    updateUser     as modifyUser,
-    deleteUser     as removeUser
+    getUserById         as findUserById,
+    getUserByDocumento  as findUserByDocumento,
+    createUser          as insertUser,
+    updateUser          as modifyUser,
+    deleteUser          as removeUser
 } from '../models/user.model.js';
 
 import { getTasksByUserId } from '../models/task.model.js';
@@ -99,6 +100,25 @@ export async function deleteUser(req, res) {
     } catch (error) {
         console.error('Error en deleteUser:', error);
         res.status(500).json({ error: 'Error al eliminar el usuario' });
+    }
+}
+
+// GET /api/users/by-document/:documento
+// Busca un usuario por su número de documento — usado por el frontend para el modo usuario
+// Va ANTES de /:id en las rutas para que Express no capture "by-document" como id
+export async function getUserByDocumento(req, res) {
+    try {
+        const { documento } = req.params;
+        const usuario = await findUserByDocumento(documento);
+
+        if (!usuario) {
+            return res.status(404).json({ error: `No existe un usuario con el documento ${documento}` });
+        }
+
+        res.status(200).json(usuario);
+    } catch (error) {
+        console.error('Error en getUserByDocumento:', error);
+        res.status(500).json({ error: 'Error al buscar el usuario por documento' });
     }
 }
 

--- a/src/models/task.model.js
+++ b/src/models/task.model.js
@@ -65,20 +65,24 @@ export async function getAllTasks() {
     // Se obtienen todas las tareas de la tabla tasks
     const [rows]     = await pool.query('SELECT * FROM tasks');
     // Se obtienen todos los usuarios para resolver los IDs a nombres
-    const [usuarios] = await pool.query('SELECT id, name FROM users');
+    const [usuarios] = await pool.query('SELECT id, name, documento FROM users');
 
     return rows.map(function(fila) {
         const tarea   = formatearTarea(fila);
 
-        // Se recorre assignedUsers y se busca el nombre de cada id en el arreglo de usuarios
         const nombres = tarea.assignedUsers.map(function(id) {
             const encontrado = usuarios.find(u => u.id === Number(id));
             return encontrado ? encontrado.name : null;
-        }).filter(Boolean); // filter(Boolean) elimina los null (ids que ya no existen)
+        }).filter(Boolean);
 
-        // assignedUsersDisplay: string con los nombres separados por coma,
-        // o null si no hay usuarios asignados (el frontend muestra 'Sin asignar')
         tarea.assignedUsersDisplay = nombres.length > 0 ? nombres.join(', ') : null;
+
+        // assignedDocumentos: permite filtrar por documento en el panel admin
+        tarea.assignedDocumentos = tarea.assignedUsers.map(function(id) {
+            const encontrado = usuarios.find(u => u.id === Number(id));
+            return encontrado ? encontrado.documento.toString() : null;
+        }).filter(Boolean);
+
         return tarea;
     });
 }

--- a/src/routes/users.routes.js
+++ b/src/routes/users.routes.js
@@ -20,6 +20,7 @@ import { Router } from 'express';
 import {
     getUsers,
     getUserById,
+    getUserByDocumento,
     createUser,
     updateUser,
     deleteUser,
@@ -38,6 +39,11 @@ router.get('/', getUsers);
 router.post('/', createUser);
 
 // ── RUTAS CON SEGMENTO FIJO AL FINAL (van ANTES de /:id) ─────────────────────
+
+// GET /api/users/by-document/:documento — busca un usuario por su número de documento.
+// CRÍTICO: va ANTES de /:id para que Express no interprete "by-document" como un id.
+// El frontend lo usa en el modo usuario para buscar por documento sin traer todos los usuarios.
+router.get('/by-document/:documento', getUserByDocumento);
 
 // GET /api/users/:userId/tasks — retorna todas las tareas asignadas a un usuario.
 // CORRECCIÓN: esta ruta va ANTES de /:id para que Express no interprete


### PR DESCRIPTION
## Descripción del Cambio

Se corrigieron múltiples bugs que impedían buscar usuarios por documento tanto en el panel
usuario como en el panel admin, se movió el botón Editar al panel administrador, y se
optimizó la actualización de la tabla para que sea instantánea en lugar de hacer un GET
completo al servidor después de cada operación.

## Tipo de Cambio

- [x] **fix**: Corrección de error.
- [x] **feat**: Nueva funcionalidad.
- [x] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas

**Vínculo:** Closes #51 

---

## Checklist de Calidad Universal

- [x] **Sincronización:** He actualizado mi rama con `origin/release` y resolví conflictos.
- [x] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [x] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.

### Validación FRONTEND (Si aplica)

- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).

### Validación BACKEND (Si aplica)

- [x] **Endpoints:** He probado las rutas en Postman/Thunder Client y retornan el código HTTP correcto.
- [x] **Validación:** Se implementó manejo de errores (try/catch) y validación de datos de entrada.
- [x] **Modelos:** Los cambios en la base de datos o modelos fueron comunicados al equipo.

---

## Evidencia de Trabajo

*Adjunta un screenshot del panel funcionando o un snippet del JSON de respuesta del endpoint /by-document/:documento.*

## Análisis de Impacto

- El backend expone una ruta nueva: `GET /api/users/by-document/:documento`. El equipo no necesita correr `npm install`, pero sí reiniciar el servidor backend para que la ruta quede activa.
- El schema.sql fue actualizado: la columna `comment` ahora está en el `CREATE TABLE` original. Quien recree la base de datos desde cero debe usar el schema actualizado.
- Se recomienda correr `git rm --cached .env` en el repositorio backend si el archivo `.env` fue commiteado anteriormente.

## Evidencia de Trabajo

*Adjunta un screenshot del panel funcionando*
<img width="1919" height="973" alt="image" src="https://github.com/user-attachments/assets/5aa2bc87-b58e-447a-a587-0bc824c00ecd" />
<img width="721" height="228" alt="image" src="https://github.com/user-attachments/assets/8629cd63-7460-4a20-8f97-ee265b4d9a41" />
<img width="729" height="281" alt="image" src="https://github.com/user-attachments/assets/890c2a66-1a5f-4663-bfa5-9135bebf5b9f" />

---

## Detalle de archivos modificados

| Archivo | Cambio |
|---|---|
| `backend/src/controller/users.controller.js` | Se añadió `getUserByDocumento` |
| `backend/src/routes/users.routes.js` | Se añadió ruta `GET /by-document/:documento` antes de `/:id` |
| `backend/src/models/task.model.js` | Se añadió `documento` al SELECT y se construye `assignedDocumentos` por tarea |
| `backend/database/schema.sql` | Columna `comment` movida al `CREATE TABLE` original |
| `frontend/src/api/tareasApi.js` | `buscarUsuarioPorDocumento` usa la ruta directa; se añadió `cache: 'no-store'` |
| `frontend/src/api/usuariosApi.js` | Se añadió `cache: 'no-store'` en `obtenerTodosLosUsuarios` |
| `frontend/src/services/tareasService.js` | Se guarda el valor del documento antes de llamar `reiniciarVistaModoUsuario` |
| `frontend/src/utils/filtros.js` | Filtro ahora busca también en `assignedDocumentos` |
| `frontend/src/ui/tareasUI.js` | Se eliminó el botón Editar del panel usuario |
| `frontend/src/ui/modoUI.js` | Se añadió botón Editar en tabla admin y actualización local sin GET adicional |