### PR TITLE
Título: feat: contador usuarios unificado, favicon y limpieza de botón actualizar

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,6 +212,9 @@ npm run dev
   "status": "pendiente",
   "assignedUsers": [1, 2]
 }
+
+**Nota:** El campo `assignedUsers` es un array de IDs numéricos de usuarios. En la arquitectura actual, este campo es gestionado por el frontend desde el panel de administración al crear o asignar tareas. Al consumir este endpoint directamente (por ejemplo desde Postman), se puede enviar vacío `[]` o con los IDs deseados.
+
 ```
 
 **Query params para GET `/api/tasks/filter`:**

--- a/md/infoTecBackend.md
+++ b/md/infoTecBackend.md
@@ -102,6 +102,9 @@ models/ (userModel.js, taskModel.js — datos en memoria y operaciones CRUD)
   "status": "pendiente",
   "assignedUsers": [1, 2]
 }
+
+**Nota:** El campo `assignedUsers` es un array de IDs numéricos de usuarios. En la arquitectura actual, este campo es gestionado por el frontend desde el panel de administración al crear o asignar tareas. Al consumir este endpoint directamente (por ejemplo desde Postman), se puede enviar vacío `[]` o con los IDs deseados.
+
 ```
 
 ### Valores válidos para status


### PR DESCRIPTION
Título: docs: aclarar responsabilidad de assignedUsers en README

## Descripción del Cambio
Se actualizó la documentación del endpoint POST /api/tasks para aclarar que el campo 
assignedUsers es gestionado por el frontend, no por el consumidor directo de la API.

## Tipo de Cambio
- [x] docs / style: Documentación o formato

## Relación con Tareas
Closes #75 

## Checklist de Calidad Universal
- [x] Solo cambios en README.md, sin cambios en código funcional

## Análisis de Impacto
Sin impacto en el código. Solo documentación.