### PR TITLE
feat: capturar y persistir el campo comment al crear una tarea

### DIFF
--- a/src/controller/tasks.controller.js
+++ b/src/controller/tasks.controller.js
@@ -52,9 +52,9 @@ export const getTaskById = catchAsync(async (req, res) => {
 // Cuerpo esperado: { title, description, status, assignedUsers }
 // NOTA: la validación la realiza validateSchema(createTaskSchema) antes de llegar aquí.
 export const createTask = catchAsync(async (req, res) => {
-    const { title, description, status, assignedUsers } = req.body;
+    const { title, description, status, assignedUsers, comment } = req.body;
 
-    const nuevaTarea = await insertTask({ title, description, status, assignedUsers });
+    const nuevaTarea = await insertTask({ title, description, status, assignedUsers, comment });
     return successResponse(res, 'Tarea creada correctamente', nuevaTarea, 201);
 });
 


### PR DESCRIPTION
## Descripción del Cambio
Se actualizó el controlador de tareas para soportar la recepción y persistencia del campo comment. Anteriormente, este dato se perdía al no estar incluido en la lógica de creación del backend.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [x] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #80 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** Rama actualizada con `origin/release` y sin conflictos de merge.
- [x] **Limpieza:** Se eliminaron logs de consola y comentarios de prueba.
- [x] **Estándares:** El código sigue el patrón de diseño catchAsync para el manejo de errores asíncronos.

### Validación FRONTEND (Si aplica)
- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).

### Validación BACKEND (Si aplica)
- [x] **Controlador:** Se añadió comment a la desestructuración de req.body.
- [x] **Persistencia:** Se actualizó el llamado a insertTask para pasar el comentario al modelo/BD.
- [x] **Respuesta:** Se validó que successResponse retorne el código 201 y la nueva tarea creada.

---

## Evidencia de Trabajo
- Archivo modificado: src/controller/tasks.controller.js.
- Persistencia: El campo comment ahora es procesado junto con title, description, status y assignedUsers.
<img width="957" height="254" alt="image" src="https://github.com/user-attachments/assets/2cfb2dd0-a111-4712-ba30-cdbfd71f3a43" />


## Análisis de Impacto
Este cambio no afecta la compatibilidad con versiones anteriores, ya que el campo comment se trata como un valor opcional en la desestructuración, permitiendo que las peticiones que no lo incluyan sigan funcionando correctamente.