### PR TITLE
feat(auth): middleware verifyToken y protección de rutas privadas

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1412,8 +1412,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "license": "MIT",
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/unpipe": {
       "version": "1.0.0",

--- a/src/app.js
+++ b/src/app.js
@@ -9,6 +9,7 @@ import cors from 'cors';
 
 import { errorMiddleware } from './middlewares/error.middleware.js';
 import authRouter from './routes/auth.routes.js';
+import { verifyToken } from './middlewares/auth.middleware.js';
 import usersRouter from './routes/users.routes.js';
 import tasksRouter from './routes/tasks.routes.js';
 
@@ -36,11 +37,9 @@ app.get('/', (req, res) => {
 // Karol agregará verifyToken a /api/users y /api/tasks en su rama
 app.use('/api/auth', authRouter);
 
-// rutas de usuarios: GET/POST/PUT/DELETE /api/users
-app.use('/api/users', usersRouter);
-
-// rutas de tareas: GET/POST/PUT/PATCH/DELETE /api/tasks
-app.use('/api/tasks', tasksRouter);
+// Rutas protegidas — verifyToken valida el JWT antes de llegar al controlador
+app.use('/api/users', verifyToken, usersRouter);
+app.use('/api/tasks', verifyToken, tasksRouter);
 
 // Middleware global de errores — debe registrarse DESPUÉS de todas las rutas
 // Si se registra antes, los errores de las rutas no llegarán aquí

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -1,0 +1,53 @@
+// MÓDULO: middlewares/auth.middleware.js
+// CAPA: Middlewares (guardianes de las rutas)
+//
+// Responsabilidad única: verificar que el token JWT sea válido antes
+// de permitir el acceso a cualquier ruta protegida.
+//
+// REGLA OBLIGATORIA (guía del instructor):
+// Los mensajes de error son SIEMPRE en español y en formato JSON.
+//   { "error": "Acceso denegado: Token requerido" }
+//   { "error": "Acceso denegado: El token ha expirado, inicie sesión nuevamente" }
+//   { "error": "Acceso denegado: Token inválido" }
+
+import jwt from 'jsonwebtoken';
+
+// verifyToken — se agrega como segundo argumento en las rutas a proteger:
+//   app.use('/api/tasks', verifyToken, tasksRouter)
+//
+// Si el token es válido adjunta req.usuario con el payload decodificado
+// y llama a next() para continuar a la ruta.
+export function verifyToken(req, res, next) {
+    // El token viaja en el header: Authorization: Bearer <token>
+    const authHeader = req.headers['authorization'];
+
+    // Si no viene el header o no tiene el formato "Bearer ..." se deniega el acceso
+    if (!authHeader || !authHeader.startsWith('Bearer ')) {
+        return res.status(401).json({ error: 'Acceso denegado: Token requerido' });
+    }
+
+    // Se extrae solo el token (la parte después del espacio de "Bearer ")
+    const token = authHeader.split(' ')[1];
+
+    try {
+        // jwt.verify lanza un error si el token es inválido o expiró
+        const payload = jwt.verify(token, process.env.JWT_SECRET);
+
+        // Se adjunta el payload al request para que los controladores lo usen
+        // Ejemplo de uso en un controlador: const { id, role } = req.usuario;
+        req.usuario = payload;
+
+        // Token válido — continuar al siguiente middleware o ruta
+        next();
+
+    } catch (error) {
+        // TokenExpiredError se lanza cuando el tiempo de vida del token venció
+        if (error.name === 'TokenExpiredError') {
+            return res.status(401).json({
+                error: 'Acceso denegado: El token ha expirado, inicie sesión nuevamente',
+            });
+        }
+        // Cualquier otro error: firma inválida, token malformado, etc.
+        return res.status(401).json({ error: 'Acceso denegado: Token inválido' });
+    }
+}


### PR DESCRIPTION
## Descripción del Cambio
Implementación de la capa de seguridad del backend:
- `auth.middleware.js`: función verifyToken que valida el JWT en el header
  Authorization y responde con los tres mensajes de error en español obligatorios.
- `app.js`: rutas /api/users y /api/tasks protegidas con verifyToken.
  La ruta /api/auth sigue siendo pública.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [ ] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #83 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** rama actualizada con `origin/release` y sin conflictos.
- [x] **Limpieza:** sin `console.log` innecesarios.
- [x] **Estándares:** función verifyToken documentada con JSDoc.

### Validación FRONTEND (Si aplica)
- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).

### Validación BACKEND (Si aplica)
- [x] Probado en Postman: sin token, token inválido, token válido, ruta pública.
- [x] Los tres mensajes de error están exactamente en español como exige la guía.
- [x] La ruta /api/auth NO tiene verifyToken (es pública).

---

## Evidencia de Trabajo
*Adjunta un screenshot (Frontend) o un snippet del JSON de respuesta (Backend).*

Caso 1 — Sin token:
<img width="1206" height="729" alt="Image" src="https://github.com/user-attachments/assets/25fcd802-0101-4cf6-af6d-80d69e91750e" />

Caso 2 — Token con firma inválida:
<img width="1229" height="675" alt="Image" src="https://github.com/user-attachments/assets/362b4edf-c035-4a2c-973e-7f057a4061af" />

Caso 3 — Con token válido:
<img width="1236" height="718" alt="Image" src="https://github.com/user-attachments/assets/e7e1eed2-92bc-4ad3-b7ae-90fe0d86f1f9" />

Caso 4 — Ruta pública sigue funcionando sin token:
<img width="1241" height="897" alt="Image" src="https://github.com/user-attachments/assets/824d6f6f-9fc9-4b3b-85bb-f2c11f00c3ad" />

## Análisis de Impacto
Depende de que el PR de Sebas (developer) esté mergeado en release.
Paulo necesita que este PR esté mergeado para construir el endpoint de refresh.
Karol debe comunicar al equipo las contraseñas de prueba para sus tests locales.