### PR TITLE
feat(auth): endpoint refresh token para renovación automática de sesión

### DIFF
--- a/src/controller/auth.refresh.controller.js
+++ b/src/controller/auth.refresh.controller.js
@@ -1,0 +1,48 @@
+// MÓDULO: controller/auth.refresh.controller.js
+// CAPA: Controlador (recibe HTTP, llama el servicio, responde HTTP)
+//
+// Responsabilidad única: manejar la renovación del accessToken.
+// Se separa de auth.controller.js para respetar el Principio de
+// Responsabilidad Única (SRP): cada controlador maneja una sola operación.
+
+import { catchAsync }                     from '../utils/catchAsync.js';
+import { successResponse, errorResponse } from '../utils/response.util.js';
+import { renovarAccessTokenService }      from '../services/auth.service.js';
+
+// POST /api/auth/refresh
+// Cuerpo esperado: { refreshToken }
+// Respuesta exitosa 200: { success, message, data: { accessToken } }
+// Error 401: refreshToken faltante, expirado o inválido (en español)
+export const refresh = catchAsync(async (req, res) => {
+    const { refreshToken } = req.body;
+
+    // Validar que venga el refreshToken en el body
+    if (!refreshToken) {
+        return errorResponse(res, 'Acceso denegado: Refresh token requerido', 401);
+    }
+
+    try {
+        // El servicio de Sebas (auth.service.js) valida la firma con JWT_REFRESH_SECRET
+        // y retorna un nuevo accessToken, o null si el usuario ya no existe
+        const nuevoAccessToken = await renovarAccessTokenService(refreshToken);
+
+        if (!nuevoAccessToken) {
+            return errorResponse(res, 'Acceso denegado: Token inválido', 401);
+        }
+
+        // Retornar solo el nuevo accessToken — el refreshToken sigue siendo el mismo
+        return successResponse(res, 'Token renovado correctamente', { accessToken: nuevoAccessToken });
+
+    } catch (error) {
+        // TokenExpiredError — el refreshToken también venció, el usuario debe hacer login
+        if (error.name === 'TokenExpiredError') {
+            return errorResponse(
+                res,
+                'Acceso denegado: El token ha expirado, inicie sesión nuevamente',
+                401
+            );
+        }
+        // JsonWebTokenError u otro error de firma
+        return errorResponse(res, 'Acceso denegado: Token inválido', 401);
+    }
+});

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -6,6 +6,7 @@
 
 import { Router }         from 'express';
 import { login }          from '../controller/auth.controller.js';
+import { refresh }        from '../controller/auth.refresh.controller.js';
 import { validateSchema } from '../middlewares/validator.middleware.js';
 import { loginSchema }    from '../../schemas/auth.schema.js';
 
@@ -14,7 +15,7 @@ const router = Router();
 // POST /api/auth/login — validateSchema(loginSchema) valida documento y password antes de llegar al controlador
 router.post('/login', validateSchema(loginSchema), login);
 
-// POST /api/auth/refresh — lo agrega Paulo en su rama
-// router.post('/refresh', refresh);
+// POST /api/auth/refresh — renueva el accessToken con el refreshToken de larga duración
+router.post('/refresh', refresh);
 
 export default router;


### PR DESCRIPTION
# Descripción del Cambio
Implementación del endpoint POST /api/auth/refresh que recibe el refreshToken,
valida su firma con JWT_REFRESH_SECRET (la clave de Sebas en .env) y emite un
nuevo accessToken sin requerir que el usuario haga login de nuevo.
Este endpoint es consumido por el interceptor del frontend (fetchConAuth.js).

# Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.

## Relación con Tareas
**Vínculo:** Closes #84 

---

## Checklist de Calidad Universal
- [x] Sincronización: rama actualizada con `origin/release` y sin conflictos.
- [x] Limpieza: sin `console.log` innecesarios.
- [x] Estándares: funciones documentadas con JSDoc.

### Validación BACKEND
- [x] Probado en Postman: refresh exitoso, sin token, token inválido.
- [x] Mensajes de error en español con formato JSON estándar del proyecto.]

## Análisis de Impacto
Depende de que el PR de Sebas (developer) esté mergeado en release.
El frontend (mi rama desarrollador) consume este endpoint.