### PR TITLE
feat(auth): agregar endpoint de registro con bcrypt, validaciones Zod y verificacion de duplicados

### DIFF
--- a/src/controller/auth.controller.js
+++ b/src/controller/auth.controller.js
@@ -6,7 +6,7 @@
 
 import { catchAsync }                     from '../utils/catchAsync.js';
 import { successResponse, errorResponse } from '../utils/response.util.js';
-import { loginService }                   from '../services/auth.service.js';
+import { loginService, registerService }  from '../services/auth.service.js';
 
 // POST /api/auth/login
 // Cuerpo: { documento, password }
@@ -14,10 +14,10 @@ import { loginService }                   from '../services/auth.service.js';
 // Error 400: campos faltantes
 // Error 401: credenciales incorrectas
 export const login = catchAsync(async (req, res) => {
-    const { documento, password } = req.body;
+    const { email, password } = req.body;
 
-    // El servicio valida las credenciales — retorna los datos o null
-    const resultado = await loginService({ documento, password });
+    //El servicio valida las credenciales - retorna los datos o NULL 
+    const resultado = await loginService({ email, password });
 
     // null significa credenciales incorrectas
     if (!resultado) {
@@ -25,4 +25,32 @@ export const login = catchAsync(async (req, res) => {
     }
 
     return successResponse(res, 'Inicio de sesión exitoso', resultado);
+});
+
+// ── POST /api/auth/register ──────────────────────────────────────────────────
+// Registra un nuevo usuario en el sistema.
+// Cuerpo esperado (validado por validateSchema(registerSchema) en la ruta):
+//   { name, documento, email, password }
+//
+// Respuesta exitosa 201: { success, message, data: { usuario sin password } }
+// Error 409: el email o documento ya están registrados
+// Error 400: datos inválidos (lo maneja el middleware de validación)
+//
+// catchAsync captura cualquier error async y lo pasa al middleware global
+// de errores sin necesidad de un bloque try/catch manual aquí.
+export const register = catchAsync(async (req, res) => {
+    // req.body ya fue validado y limpiado por validateSchema(registerSchema)
+    const { name, documento, email, password } = req.body;
+
+    // registerService maneja la lógica: verifica duplicados, hashea y crea
+    // Retorna { error, codigo } si hay conflicto, o { usuario } si fue exitoso
+    const resultado = await registerService({ name, documento, email, password });
+
+    // Si el servicio retornó un error significa que el email o documento ya existen
+    if (resultado.error) {
+        return errorResponse(res, resultado.error, resultado.codigo);
+    }
+
+    // Si llegamos aquí el registro fue exitoso — respondemos con 201 Created
+    return successResponse(res, 'Usuario registrado correctamente', resultado.usuario, 201);
 });

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -80,16 +80,6 @@ export async function updateUser(id, campos) {
     return getUserById(id);
 }
 
-// elimina un usuario de la tabla users
-// primero guarda el objeto para retornarlo y confirmar qué se eliminó
-export async function deleteUser(id) {
-    const aEliminar = await getUserById(id);
-    if (!aEliminar) return null;
-
-    await pool.query('DELETE FROM users WHERE id = ?', [Number(id)]);
-    return aEliminar;
-}
-
 // ── NUEVA FUNCIÓN: busca usuario por email ───────────────────────────────────
 // GET interno — se usa en loginService y registerService de auth.service.js
 // Antes el login buscaba por documento. Ahora busca por email porque el
@@ -104,4 +94,39 @@ export async function getUserByEmail(email) {
     );
     // rows[0] es el primer resultado o undefined si no hay coincidencia
     return rows[0];
+}
+
+// ── CREAR USUARIO CON CONTRASEÑA Y ROL ───────────────────────────────────────
+// Se usa exclusivamente desde registerService en auth.service.js.
+// La función createUser que ya existe en este archivo no acepta password ni role,
+// por eso se crea esta variante separada para el flujo de registro.
+//
+// Parámetros:
+//   name     — nombre completo del usuario
+//   documento — número de documento de identidad (solo dígitos)
+//   email    — correo electrónico del usuario
+//   password — contraseña ya hasheada con bcrypt (NUNCA texto plano)
+//   role     — rol del usuario ('user' o 'admin'), por defecto 'user'
+//
+// Retorna el objeto completo del usuario recién creado (incluyendo password
+// para que registerService pueda excluirlo antes de responder al cliente).
+export async function createUserWithPassword({ name, documento, email, password, role = 'user' }) {
+    // INSERT con los 5 campos: los 3 básicos + password hasheada + role
+    const [result] = await pool.query(
+        'INSERT INTO users (name, documento, email, password, role) VALUES (?, ?, ?, ?, ?)',
+        [name, documento, email, password, role]
+    );
+    // result.insertId es el id AUTO_INCREMENT que MySQL asignó a la nueva fila
+    // Se usa getUserById (ya existe en este archivo) para retornar el objeto completo
+    return getUserById(result.insertId);
+}
+
+// elimina un usuario de la tabla users
+// primero guarda el objeto para retornarlo y confirmar qué se eliminó
+export async function deleteUser(id) {
+    const aEliminar = await getUserById(id);
+    if (!aEliminar) return null;
+
+    await pool.query('DELETE FROM users WHERE id = ?', [Number(id)]);
+    return aEliminar;
 }

--- a/src/routes/auth.routes.js
+++ b/src/routes/auth.routes.js
@@ -1,21 +1,28 @@
+// src/routes/auth.routes.js
 // MÓDULO: routes/auth.routes.js
 // CAPA: Rutas
 //
 // Responsabilidad única: definir los endpoints de autenticación.
-// El endpoint /refresh lo completa Paulo en su rama.
+// ACTUALIZACIÓN: se agrega la ruta de registro POST /register.
 
 import { Router }         from 'express';
-import { login }          from '../controller/auth.controller.js';
+import { login, register } from '../controller/auth.controller.js';
 import { refresh }        from '../controller/auth.refresh.controller.js';
 import { validateSchema } from '../middlewares/validator.middleware.js';
-import { loginSchema }    from '../../schemas/auth.schema.js';
+import { loginSchema, registerSchema } from '../../schemas/auth.schema.js';
 
 const router = Router();
 
-// POST /api/auth/login — validateSchema(loginSchema) valida documento y password antes de llegar al controlador
+// POST /api/auth/login — valida email y password con loginSchema antes de llegar al controlador
 router.post('/login', validateSchema(loginSchema), login);
 
 // POST /api/auth/refresh — renueva el accessToken con el refreshToken de larga duración
+// No requiere validación de schema porque solo recibe el refreshToken
 router.post('/refresh', refresh);
+
+// POST /api/auth/register — nuevo endpoint para registro de usuarios desde la web
+// validateSchema(registerSchema) valida name, documento, email y password
+// antes de que la petición llegue al controlador
+router.post('/register', validateSchema(registerSchema), register);
 
 export default router;

--- a/src/services/auth.service.js
+++ b/src/services/auth.service.js
@@ -7,7 +7,12 @@
 
 import jwt    from 'jsonwebtoken';
 import bcrypt from 'bcryptjs';
-import { getUserByEmail, getUserById } from '../models/user.model.js';
+import {
+    getUserByEmail,
+    getUserById,
+    getUserByDocumento,
+    createUserWithPassword,
+} from '../models/user.model.js';
 
 // Rondas de hashing para bcrypt.
 // 10 es el estándar recomendado por OWASP: buen balance entre seguridad y velocidad.
@@ -107,4 +112,62 @@ export async function renovarAccessTokenService(refreshToken) {
 
     // Emitir un nuevo accessToken con los datos actuales del usuario
     return generarAccessToken(usuario);
+}
+
+// ── REGISTRO DE USUARIO ──────────────────────────────────────────────────────
+// POST /api/auth/register
+// Cuerpo: { name, documento, email, password }
+//
+// Este servicio es nuevo: no existía antes porque el sistema dependía del
+// script manual scripts/changePassword.js para crear usuarios con contraseña.
+// Ahora el usuario puede registrarse directamente desde la pantalla de inicio.
+//
+// El registro:
+//   1. Verifica que el email no esté en uso (409 si ya existe)
+//   2. Verifica que el documento no esté en uso (409 si ya existe)
+//   3. Hashea la contraseña con bcrypt antes de guardarla en MySQL
+//   4. Crea el usuario con role = 'user' por defecto
+//   5. Retorna el usuario creado sin el campo password
+//
+// Retorna un objeto { error, usuario } en lugar de solo el usuario para que
+// el controlador pueda distinguir entre un éxito y un error 409 sin usar try/catch.
+export async function registerService({ name, documento, email, password }) {
+
+    // 1. Verificar que el email no esté registrado ya
+    // getUserByEmail viene del modelo de usuarios y busca en la tabla users de MySQL
+    const usuarioPorEmail = await getUserByEmail(email);
+    if (usuarioPorEmail) {
+        // Se retorna un objeto de error en lugar de lanzar excepción
+        // para que el controlador pueda responder con 409 de forma limpia
+        return { error: 'El correo electrónico ya está registrado en el sistema', codigo: 409 };
+    }
+
+    // 2. Verificar que el documento no esté registrado ya
+    // getUserByDocumento viene del modelo y busca en la columna 'documento' de la tabla users
+    const usuarioPorDocumento = await getUserByDocumento(documento);
+    if (usuarioPorDocumento) {
+        return { error: 'El número de documento ya está registrado en el sistema', codigo: 409 };
+    }
+
+    // 3. Hashear la contraseña antes de guardarla en la base de datos
+    // NUNCA se guarda una contraseña en texto plano en la BD
+    // SALT_ROUNDS = 10 es el estándar recomendado por OWASP (ya está definido arriba en el archivo)
+    const passwordHasheada = await hashearPassword(password);
+
+    // 4. Crear el usuario en MySQL con la contraseña ya hasheada
+    // createUserWithPassword es una función nueva que se agrega al modelo
+    // (ver src/models/user.model.js más abajo)
+    // El rol es 'user' por defecto — solo un admin puede cambiar el rol después
+    const usuarioCreado = await createUserWithPassword({
+        name,
+        documento,
+        email,
+        password: passwordHasheada,
+        role: 'user',
+    });
+
+    // 5. Retornar el usuario sin el campo password
+    // Se usa desestructuración para excluir password del objeto de retorno
+    const { password: _ignorado, ...usuarioSinPassword } = usuarioCreado;
+    return { usuario: usuarioSinPassword };
 }


### PR DESCRIPTION
## Descripción del Cambio
Se implementa el endpoint de registro de usuarios para que puedan crearse
cuentas directamente desde la pantalla de inicio del frontend, sin necesidad
del script manual scripts/changePassword.js.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [ ] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #88 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** He actualizado mi rama con `origin/release` y resolví conflictos.
- [x] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [x] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.

### Validación FRONTEND (Si aplica)
- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).

### Validación BACKEND (Si aplica)
- [x] POST /api/auth/register con datos válidos → 201 con usuario sin password
- [x] POST /api/auth/register con email duplicado → 409 con mensaje en español
- [x] POST /api/auth/register con documento duplicado → 409 con mensaje en español
- [x] POST /api/auth/register con campo vacío → 400 (middleware Zod)
- [x] La contraseña queda hasheada en la BD (verificado en MySQL Workbench)

---

## Evidencia de Trabajo
- POST /api/auth/register con datos válidos → 201 con usuario sin password
*Adjunta un screenshot (Frontend) o un snippet del JSON de respuesta (Backend).*
<img width="1430" height="727" alt="image" src="https://github.com/user-attachments/assets/7d31a80e-278a-4f1d-942b-909d3c54c7fd" />

- POST /api/auth/register con email duplicado → 409 con mensaje en español
<img width="1435" height="549" alt="image" src="https://github.com/user-attachments/assets/b2a6527a-c86e-4b72-807f-0a26b129a808" />

- POST /api/auth/register con documento duplicado → 409 con mensaje en español
<img width="1434" height="554" alt="image" src="https://github.com/user-attachments/assets/0be73f22-6cfe-4b98-a435-9fa02dfe24ba" />

- POST /api/auth/register con campo vacío → 400 (middleware Zod)
<img width="1433" height="916" alt="image" src="https://github.com/user-attachments/assets/ce4a19ce-bc1b-4ea6-82e6-9b4e10c4fabe" />


## Archivos modificados
- schemas/auth.schema.js (se agrega registerSchema)
- src/models/user.model.js (se agregan getUserByEmail y createUserWithPassword)
- src/services/auth.service.js (se agrega registerService, import actualizado)
- src/controller/auth.controller.js (se agrega función register)
- src/routes/auth.routes.js (se registra POST /register con validación)

## Análisis de Impacto
Karol puede ahora implementar el modal de registro en el frontend (Issue 74).
Los compañeros no necesitan ejecutar npm install (sin dependencias nuevas).