### PR TITLE
feat(users): agregar endpoint PATCH /api/users/:id/role con middleware requireAdmin (#90)

### DIFF
--- a/schemas/user.schema.js
+++ b/schemas/user.schema.js
@@ -53,3 +53,18 @@ export const createUserSchema = z.object({
 // Igual que createUserSchema pero todos los campos son opcionales (partial)
 // Permite actualizar solo documento, solo name, solo email o cualquier combinación
 export const updateUserSchema = createUserSchema.partial();
+
+// ── SCHEMA PARA CAMBIAR ROL ──────────────────────────────────────────────────
+// PATCH /api/users/:id/role
+// Cuerpo esperado: { role: 'admin' | 'user' }
+//
+// Solo acepta los dos valores válidos del sistema.
+// validateSchema(changeRoleSchema) se aplica en la ruta correspondiente.
+export const changeRoleSchema = z.object({
+    // role: obligatorio, solo acepta 'admin' o 'user'
+    // El mensaje de error en español explica exactamente qué se acepta
+    role: z.enum(['admin', 'user'], {
+        required_error: 'El rol es obligatorio',
+        message:        "El rol debe ser 'admin' o 'user'",
+    }),
+});

--- a/src/controller/users.controller.js
+++ b/src/controller/users.controller.js
@@ -20,7 +20,8 @@ import {
     getUserByDocumento  as findUserByDocumento,
     createUser          as insertUser,
     updateUser          as modifyUser,
-    deleteUser          as removeUser
+    deleteUser          as removeUser,
+    updateUserRole,                          // ← nueva función
 } from '../models/user.model.js';
 
 import { getTasksByUserId } from '../models/task.model.js';
@@ -112,4 +113,37 @@ export const getUserTasks = catchAsync(async (req, res) => {
     const { userId } = req.params;
     const tareas     = await getTasksByUserId(userId);
     return successResponse(res, 'Tareas del usuario obtenidas correctamente', tareas);
+});
+
+// ── PATCH /api/users/:id/role ────────────────────────────────────────────────
+// Cambia el rol de un usuario entre 'admin' y 'user'.
+// Solo accesible para usuarios autenticados con role = 'admin'.
+// (El middleware requireAdmin verifica esto antes de que llegue aquí.)
+//
+// Cuerpo esperado (validado por validateSchema(changeRoleSchema)):
+//   { role: 'admin' | 'user' }
+//
+// Respuesta exitosa 200: { success, message, data: usuario sin password }
+// Error 404: el id no existe
+export const changeUserRole = catchAsync(async (req, res) => {
+    const { id }       = req.params;
+    const { role }     = req.body;
+
+    // updateUserRole actualiza solo el campo role en MySQL
+    // Retorna el usuario actualizado, o null si el id no existe
+    const usuarioActualizado = await updateUserRole(id, role);
+
+    if (!usuarioActualizado) {
+        return errorResponse(res, `Usuario con id ${id} no encontrado`, 404);
+    }
+
+    // Construir la respuesta sin el campo password
+    // Se usa desestructuración para excluir el campo sensible antes de enviar
+    const { password: _ignorado, ...usuarioSinPassword } = usuarioActualizado;
+
+    return successResponse(
+        res,
+        `Rol de ${usuarioActualizado.name} actualizado a '${role}' correctamente`,
+        usuarioSinPassword
+    );
 });

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -51,3 +51,32 @@ export function verifyToken(req, res, next) {
         return res.status(401).json({ error: 'Acceso denegado: Token inválido' });
     }
 }
+
+// ── MIDDLEWARE: VERIFICAR QUE EL USUARIO ES ADMIN ────────────────────────────
+// Se usa como segundo middleware en rutas que solo los admin pueden usar.
+// Ejemplo de uso en la ruta: router.patch('/:id/role', verifyToken, requireAdmin, changeUserRole)
+//
+// verifyToken ya verificó la firma del JWT y adjuntó req.usuario al request.
+// requireAdmin solo verifica que req.usuario.role sea 'admin'.
+//
+// Si el usuario no es admin responde 403 Forbidden con mensaje en español.
+// 403 significa "autenticado pero sin permisos" (distinto de 401 "no autenticado").
+export function requireAdmin(req, res, next) {
+
+    // req.usuario fue adjuntado por verifyToken, que debe ejecutarse primero
+    // Si por alguna razón req.usuario no existe, denegar el acceso
+    if (!req.usuario) {
+        return res.status(401).json({ error: 'Acceso denegado: Token requerido' });
+    }
+
+    // Verificar que el rol en el payload del JWT sea 'admin'
+    // El role queda en el token al hacer login y no cambia hasta el próximo login
+    if (req.usuario.role !== 'admin') {
+        return res.status(403).json({
+            error: 'Acceso denegado: Se requieren permisos de administrador para esta acción',
+        });
+    }
+
+    // El usuario es admin — continuar al controlador
+    next();
+}

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -130,3 +130,30 @@ export async function deleteUser(id) {
     await pool.query('DELETE FROM users WHERE id = ?', [Number(id)]);
     return aEliminar;
 }
+
+// ── ACTUALIZAR ROL DE USUARIO ────────────────────────────────────────────────
+// Se usa desde changeUserRole en users.controller.js.
+// Solo actualiza el campo 'role', no toca ningún otro dato del usuario.
+//
+// Parámetros:
+//   id   — id numérico del usuario a modificar
+//   role — nuevo rol: 'admin' o 'user' (validado en el schema antes de llegar aquí)
+//
+// Retorna el usuario actualizado sin el campo password,
+// o null si el id no existe en la tabla users.
+export async function updateUserRole(id, role) {
+    // Verificar que el usuario existe antes de intentar actualizar
+    const existente = await getUserById(id);
+    if (!existente) return null;
+
+    // UPDATE solo modifica el campo role, no el updated_up timestamp
+    // mysql2 reemplaza los ? por los valores de forma segura (evita SQL injection)
+    await pool.query(
+        'UPDATE users SET role = ? WHERE id = ?',
+        [role, Number(id)]
+    );
+
+    // Retornar el usuario con los datos actualizados desde MySQL
+    // getUserById incluye todos los campos excepto que el controlador los filtre
+    return getUserById(id);
+}

--- a/src/routes/users.routes.js
+++ b/src/routes/users.routes.js
@@ -24,7 +24,8 @@ import {
     createUser,
     updateUser,
     deleteUser,
-    getUserTasks
+    getUserTasks,
+    changeUserRole,          // ← nueva función
 } from '../controller/users.controller.js';
 
 // Se importa el middleware genérico de validación (creado por Sebastián)
@@ -35,6 +36,9 @@ import {
     createUserSchema,
     updateUserSchema,
 } from '../../schemas/user.schema.js';
+
+import { requireAdmin } from '../middlewares/auth.middleware.js';
+import { changeRoleSchema } from '../../schemas/user.schema.js';
 
 const router = Router();
 
@@ -69,5 +73,11 @@ router.put('/:id', validateSchema(updateUserSchema), updateUser);
 
 // DELETE /api/users/:id — elimina un usuario del sistema (no requiere validación de body)
 router.delete('/:id', deleteUser);
+
+// PATCH /api/users/:id/role — cambia el rol de un usuario
+// verifyToken ya se aplica en app.js para todas las rutas /api/users
+// requireAdmin verifica adicionalmente que el usuario autenticado sea admin
+// validateSchema(changeRoleSchema) valida que role sea 'admin' o 'user'
+router.patch('/:id/role', requireAdmin, validateSchema(changeRoleSchema), changeUserRole);
 
 export default router;


### PR DESCRIPTION
## Descripción del Cambio
Se implementa el endpoint PATCH /api/users/:id/role que permite a un administrador
cambiar el rol de cualquier usuario entre 'admin' y 'user'. Se agrega el middleware
requireAdmin para proteger esta ruta de usuarios no autorizados.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [ ] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #90 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** He actualizado mi rama con `origin/develop` y resolví conflictos.
- [x] **Limpieza:** Sin `console.log`, comentarios de prueba o archivos `.env`.
- [x] **Estándares:** Uso de JSDoc para funciones y nombres de variables en camelCase.

### Validación FRONTEND (Si aplica)
- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).


### Validación BACKEND (Si aplica)
- [x] PATCH /api/users/:id/role con token admin → 200 con usuario actualizado
- [x] PATCH /api/users/:id/role con token user → 403 con mensaje en español
- [x] PATCH /api/users/:id/role con id inexistente → 404
- [x] PATCH /api/users/:id/role con role inválido → 400 (middleware Zod)

---

## Evidencia de Trabajo
*Adjunta un screenshot (Frontend) o un snippet del JSON de respuesta (Backend).*
- PATCH /api/users/:id/role con token admin → 200 con usuario actualizado
<img width="1431" height="710" alt="image" src="https://github.com/user-attachments/assets/5299ebfe-0aa6-48d6-a87e-fcac8d41ae1b" />

- PATCH /api/users/:id/role con token user → 403 con mensaje en español
<img width="1424" height="525" alt="image" src="https://github.com/user-attachments/assets/6515c4a0-a270-409b-a70a-876f793e61a4" />

- PATCH /api/users/:id/role con id inexistente → 404
<img width="1427" height="543" alt="image" src="https://github.com/user-attachments/assets/6b79f920-de83-4efd-8fb7-f978efb0602e" />

- PATCH /api/users/:id/role con role inválido → 400 (middleware Zod)
<img width="1439" height="646" alt="image" src="https://github.com/user-attachments/assets/92015160-bde5-476f-aecf-7da5cd90cb11" />

## Archivos modificados
- src/middlewares/auth.middleware.js (nueva función requireAdmin)
- src/models/user.model.js (nueva función updateUserRole)
- schemas/user.schema.js (nuevo schema changeRoleSchema)
- src/controller/users.controller.js (nueva función changeUserRole)
- src/routes/users.routes.js (nueva ruta PATCH /:id/role)

## Análisis de Impacto
Karol puede ahora agregar el botón de cambio de rol en la tabla de usuarios del
panel admin (Issue 77). Los compañeros no necesitan ejecutar npm install.