### PR TITLE
feat: tabla usuarios restructurada, desactivar/activar, buscador instructor, dropdown unificado, calendario instructor, panel calificación, fix campos opcionales y comentarios backend

### DIFF
--- a/database/rbac.sql
+++ b/database/rbac.sql
@@ -52,7 +52,8 @@ CREATE TABLE IF NOT EXISTS permissions (
 -- TABLA: role_permissions
 -- Tabla pivote que materializa la relación M:N entre roles y permisos.
 -- Un rol puede tener múltiples permisos y un permiso puede estar en múltiples roles.
--- ON DELETE CASCADE: si se elimina un rol o permiso, se eliminan sus relaciones.
+-- ON DELETE RESTRICT: MySQL bloquea eliminar un rol o permiso que tenga relaciones activas.
+--   Esto obliga a limpiar las relaciones antes de eliminar el rol o permiso padre.
 -- ============================================================
 CREATE TABLE IF NOT EXISTS role_permissions (
     role_id       INT NOT NULL,
@@ -61,12 +62,12 @@ CREATE TABLE IF NOT EXISTS role_permissions (
     CONSTRAINT fk_rp_role
         FOREIGN KEY (role_id)
         REFERENCES roles (id)
-        ON DELETE CASCADE
+        ON DELETE RESTRICT
         ON UPDATE CASCADE,
     CONSTRAINT fk_rp_permission
         FOREIGN KEY (permission_id)
         REFERENCES permissions (id)
-        ON DELETE CASCADE
+        ON DELETE RESTRICT
         ON UPDATE CASCADE
 );
 
@@ -74,7 +75,9 @@ CREATE TABLE IF NOT EXISTS role_permissions (
 -- TABLA: user_roles
 -- Tabla pivote que materializa la relación M:N entre usuarios y roles.
 -- Un usuario puede tener múltiples roles (ej: admin Y instructor a la vez).
--- ON DELETE CASCADE: si se elimina un usuario, se eliminan sus asignaciones de rol.
+-- ON DELETE RESTRICT: MySQL bloquea eliminar un usuario o rol que tenga
+--   asignaciones activas en esta tabla. El admin debe desactivar al usuario
+--   en lugar de eliminarlo si tiene roles asignados.
 -- ============================================================
 CREATE TABLE IF NOT EXISTS user_roles (
     user_id    INT NOT NULL,
@@ -84,12 +87,12 @@ CREATE TABLE IF NOT EXISTS user_roles (
     CONSTRAINT fk_ur_user
         FOREIGN KEY (user_id)
         REFERENCES users (id)
-        ON DELETE CASCADE
+        ON DELETE RESTRICT
         ON UPDATE CASCADE,
     CONSTRAINT fk_ur_role
         FOREIGN KEY (role_id)
         REFERENCES roles (id)
-        ON DELETE CASCADE
+        ON DELETE RESTRICT
         ON UPDATE CASCADE
 );
 

--- a/md/documentacionFinal.md
+++ b/md/documentacionFinal.md
@@ -1,0 +1,259 @@
+# Documentación Final — Sistema de Gestión de Tareas
+
+**Institución:** SENA — Técnico en Programación de Software — Código 3233198  
+**Equipo:** Karol Nicolle Torres Fuentes (Líder) | Juan Sebastián Patiño Hernández (Desarrollador)  
+**Fecha:** 2026
+
+---
+
+## 1. Descripción General del Sistema
+
+El Sistema de Gestión de Tareas es una aplicación web full-stack que permite administrar tareas académicas dentro del contexto del SENA. Resuelve el problema de seguimiento manual de asignaciones entre instructores y estudiantes, proporcionando un panel centralizado con roles diferenciados.
+
+**Usuarios objetivo:**
+- Administradores: gestión total del sistema (usuarios, tareas, roles)
+- Instructores: creación y calificación de tareas de sus estudiantes
+- Estudiantes: visualización y actualización de sus propias tareas
+
+**Contexto:** desarrollado como proyecto integrador del Técnico en Programación de Software, aplicando arquitectura MVC, autenticación JWT y control de acceso por roles (RBAC).
+
+---
+
+## 2. Arquitectura del Sistema
+
+### Frontend (`transferencia_dom_parejas`)
+
+```
+index.html (punto de entrada único)
+    └── src/main.js (DOMContentLoaded — inicialización)
+            ├── src/ui/modoUI.js        (activación de vistas y eventos)
+            ├── src/ui/tareasUI.js      (construcción DOM de tabla de tareas)
+            ├── src/services/tareasService.js  (coordinación de flujos)
+            ├── src/api/tareasApi.js    (fetch hacia /api/tasks)
+            ├── src/api/usuariosApi.js  (fetch hacia /api/users)
+            ├── src/api/authApi.js      (fetch hacia /api/auth)
+            └── src/utils/
+                    ├── fetchConAuth.js     (interceptor JWT + Silent Refresh)
+                    ├── sesion.js           (CRUD de localStorage)
+                    ├── notificaciones.js   (SweetAlert2 centralizado)
+                    ├── validaciones.js     (validación de formularios)
+                    ├── auditoria.js        (línea de tiempo en memoria)
+                    ├── rolesPermisos.js    (diccionario RBAC frontend)
+                    └── eventosCalendario.js (calendario reutilizable)
+```
+
+### Backend (`servidor_backend_parejas`)
+
+```
+src/app.js (Express — registra rutas y middlewares)
+    └── src/routes/
+            ├── auth.routes.js      (POST /login, /register, /refresh)
+            ├── users.routes.js     (CRUD de usuarios + deactivate/reactivate)
+            └── tasks.routes.js     (CRUD de tareas + assign + filter)
+    ├── src/controller/
+    ├── src/services/
+    ├── src/models/         (queries MySQL con pool)
+    ├── src/middlewares/    (verifyToken, requireAdmin, checkPermission, errorHandler)
+    └── src/utils/          (catchAsync, response.util, fetchConAuth)
+```
+
+### Flujo de datos
+
+```
+Usuario (evento DOM)
+    → modoUI.js / tareasService.js
+    → api/*.js
+    → fetchConAuth.js (agrega Authorization: Bearer <token>)
+    → Express → routes → controller → service → model → MySQL
+    ← response.util (formato { success, message, data })
+    → UI actualiza el DOM
+```
+
+---
+
+## 3. Flujo de Autenticación JWT
+
+### Registro (`POST /api/auth/register`)
+1. El usuario completa el formulario en la pantalla de inicio
+2. El frontend llama `authApi.registrar({ name, documento, email, password })`
+3. El backend valida con Zod (registerSchema), hashea la contraseña con bcrypt (10 rounds) y la guarda en MySQL con `role = 'user'`
+4. Respuesta: 201 con el usuario creado (sin campo password)
+
+### Login (`POST /api/auth/login`)
+1. El usuario ingresa email y password
+2. El backend busca el usuario por email, verifica bcrypt, confirma `is_active = 1`
+3. Si es correcto: genera `accessToken` (JWT, 1h) y `refreshToken` (JWT, 7d)
+4. El frontend guarda ambos tokens en localStorage vía `sesion.js`
+
+### Access Token
+- Payload: `{ id, documento, role }`
+- Duración: 1 hora
+- Se adjunta en el header `Authorization: Bearer <token>` en cada petición protegida
+- Lo agrega automáticamente `fetchConAuth.js` — el resto del código no lo gestiona
+
+### Refresh Token (Silent Refresh)
+- Duración: 7 días
+- Cuando una petición recibe 401, `fetchConAuth.js` llama a `POST /api/auth/refresh` con el refreshToken
+- Si la renovación es exitosa, se reintenta la petición original con el nuevo accessToken
+- Si el refreshToken también expiró: se hace logout automático y se redirige al login
+
+### Logout
+1. Se eliminan accessToken y refreshToken de localStorage (`sesion.limpiarSesion()`)
+2. Se cambia el modo del body a "inicio"
+3. El backend no mantiene estado de sesión (los JWT son stateless)
+
+---
+
+## 4. Roles y Permisos RBAC
+
+| Permiso | Admin | Instructor | Estudiante |
+|---------|:-----:|:----------:|:----------:|
+| tasks.create | ✓ | ✓ | — |
+| tasks.view.all | ✓ | ✓ | ✓ |
+| tasks.update | ✓ | ✓ | — |
+| tasks.delete.all | ✓ | ✓ | — |
+| tasks.assign | ✓ | ✓ | — |
+| tasks.status.update | ✓ | — | ✓ |
+| users.view | ✓ | ✓ | — |
+| users.edit | ✓ | — | — |
+| users.delete | ✓ | — | — |
+| users.assign.role | ✓ | — | — |
+
+### Cómo funciona `checkPermission(permiso)`
+
+El middleware `authorization.middleware.js` recibe el código del permiso requerido y retorna una función middleware que:
+1. Lee `req.usuario.id` (adjuntado por `verifyToken`)
+2. Consulta la BD con `getUserRolesAndPermissions(userId)` — no usa el JWT para esto
+3. Usa `.some()` para verificar si AL MENOS UN rol del usuario incluye el permiso
+4. Si ningún rol lo tiene: responde 403 Forbidden
+
+---
+
+## 5. Endpoints REST
+
+| Método | Ruta | Descripción | Rol requerido |
+|--------|------|-------------|---------------|
+| POST | /api/auth/login | Iniciar sesión | Público |
+| POST | /api/auth/register | Registrar usuario | Público |
+| POST | /api/auth/refresh | Renovar accessToken | Público (refreshToken) |
+| GET | /api/users | Listar todos los usuarios | admin, instructor |
+| GET | /api/users/:id | Obtener usuario por ID | admin |
+| POST | /api/users | Crear usuario | admin |
+| PUT | /api/users/:id | Actualizar usuario | admin |
+| DELETE | /api/users/:id | Eliminar usuario | admin |
+| PATCH | /api/users/:id/deactivate | Desactivar usuario | admin |
+| PATCH | /api/users/:id/reactivate | Reactivar usuario | admin |
+| PATCH | /api/users/:id/role | Cambiar rol | admin |
+| GET | /api/tasks | Listar todas las tareas | autenticado |
+| GET | /api/tasks/filter | Filtrar tareas por estado/usuario | autenticado |
+| GET | /api/tasks/dashboard | Estadísticas del dashboard | autenticado |
+| GET | /api/tasks/:id | Obtener tarea por ID | autenticado |
+| POST | /api/tasks | Crear tarea | tasks.create |
+| PUT | /api/tasks/:id | Actualizar tarea | tasks.update |
+| DELETE | /api/tasks/:id | Eliminar tarea | tasks.delete.all |
+| PATCH | /api/tasks/:id/status | Cambiar estado de tarea | tasks.status.update |
+| POST | /api/tasks/:taskId/assign | Asignar usuarios a tarea | tasks.assign |
+
+---
+
+## 6. Estructura de la Base de Datos
+
+### Tabla `users`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INT AUTO_INCREMENT PK | Identificador interno |
+| name | VARCHAR(100) | Nombre completo |
+| documento | VARCHAR(20) UNIQUE | Número de documento |
+| email | VARCHAR(100) UNIQUE | Correo electrónico |
+| password | VARCHAR(255) | Hash bcrypt |
+| role | ENUM('admin','instructor','user') | Rol legacy (compatibilidad) |
+| is_active | TINYINT(1) DEFAULT 1 | 1=activo, 0=desactivado |
+
+### Tabla `tasks`
+| Campo | Tipo | Descripción |
+|-------|------|-------------|
+| id | INT AUTO_INCREMENT PK | Identificador de la tarea |
+| title | VARCHAR(200) | Título de la tarea |
+| description | TEXT | Descripción (opcional) |
+| status | ENUM('pendiente','en_progreso','completada','pendiente_aprobacion') | Estado actual |
+| comment | VARCHAR(500) | Comentario del instructor (opcional) |
+| assigned_users | JSON | Array de IDs de usuarios asignados |
+
+### Tablas RBAC
+- `roles`: id, name (admin, instructor, user)
+- `permissions`: id, code (ej: 'tasks.create'), description
+- `role_permissions`: role_id FK→roles, permission_id FK→permissions (ON DELETE RESTRICT)
+- `user_roles`: user_id FK→users, role_id FK→roles (ON DELETE RESTRICT)
+
+---
+
+## 7. Instalación y Ejecución
+
+### Requisitos previos
+- Node.js 18+
+- MySQL 8.0
+- MySQL Workbench 8.0 CE
+- Git
+
+### Paso a paso desde cero
+
+**1. Clonar los repositorios**
+```bash
+git clone <URL_FRONTEND> transferencia_dom_parejas
+git clone <URL_BACKEND> servidor_backend_parejas
+```
+
+**2. Configurar el backend**
+```bash
+cd servidor_backend_parejas
+npm install
+```
+
+**3. Crear el archivo .env** (nunca subir a GitHub)
+```
+DB_HOST=localhost
+DB_PORT=3306
+DB_USER=app_user
+DB_PASSWORD=tu_contraseña_mysql
+DB_NAME=gestion_tareas_sena
+JWT_SECRET=cadena_larga_aleatoria_para_access_token
+JWT_REFRESH_SECRET=cadena_diferente_para_refresh_token
+JWT_EXPIRES_IN=1h
+JWT_REFRESH_EXPIRES_IN=7d
+```
+
+**4. Configurar MySQL** (abrir MySQL Workbench con root)
+```sql
+-- Ejecutar database/connection.sql con conexión root
+-- Luego ejecutar database/schema.sql con conexión app_user
+-- Luego ejecutar database/rbac.sql con conexión app_user
+```
+
+**5. Iniciar el backend**
+```bash
+npm run dev
+# Servidor en http://localhost:3000
+```
+
+**6. Configurar e iniciar el frontend**
+```bash
+cd ../transferencia_dom_parejas
+npm install
+npm run dev
+# Frontend en http://localhost:5173
+```
+
+---
+
+## 8. Glosario Técnico
+
+| Término | Definición |
+|---------|------------|
+| **JWT** | JSON Web Token — formato compacto para transmitir información segura entre cliente y servidor. Firmado con una clave secreta. |
+| **bcrypt** | Algoritmo de hashing para contraseñas. Agrega "sal" aleatoria al hash para proteger contra ataques de diccionario. |
+| **RBAC** | Role-Based Access Control — control de acceso basado en roles. Un usuario tiene roles y los roles tienen permisos. |
+| **ES Modules** | Sistema de módulos nativo de JavaScript con `import`/`export`. Permite dividir el código en archivos independientes. |
+| **Vite** | Empaquetador de frontend de alto rendimiento. Sirve los módulos en desarrollo sin compilar y hace build optimizado para producción. |
+| **SweetAlert2** | Librería para mostrar diálogos y notificaciones elegantes reemplazando los `alert()`, `confirm()` y `prompt()` nativos del navegador. |
+| **fetchConAuth** | Módulo del frontend que intercepta todas las peticiones al backend, agrega el token JWT y gestiona el Silent Refresh automáticamente. |
+| **Silent Refresh** | Técnica que renueva el accessToken de forma transparente cuando expira, sin que el usuario tenga que volver a iniciar sesión. |

--- a/src/middlewares/auth.middleware.js
+++ b/src/middlewares/auth.middleware.js
@@ -10,73 +10,88 @@
 //   { "error": "Acceso denegado: El token ha expirado, inicie sesión nuevamente" }
 //   { "error": "Acceso denegado: Token inválido" }
 
+// jsonwebtoken es la librería que permite firmar y verificar tokens JWT
+// Se usa jwt.verify() para comprobar que el token no fue alterado y no expiró
 import jwt from 'jsonwebtoken';
 
-// verifyToken — se agrega como segundo argumento en las rutas a proteger:
-//   app.use('/api/tasks', verifyToken, tasksRouter)
+// verifyToken — middleware que protege rutas del backend
+// Se registra como segundo argumento en las rutas que requieren autenticación:
+//   router.get('/api/tasks', verifyToken, tasksController)
+// Express lo ejecuta ANTES del controlador cada vez que llega una petición
 //
 // Si el token es válido adjunta req.usuario con el payload decodificado
-// y llama a next() para continuar a la ruta.
+// y llama a next() para continuar al controlador.
 export function verifyToken(req, res, next) {
-    // El token viaja en el header: Authorization: Bearer <token>
+    // req.headers['authorization'] contiene el valor del header Authorization
+    // El frontend lo envía con el formato estándar: "Bearer eyJhbGci..."
     const authHeader = req.headers['authorization'];
 
-    // Si no viene el header o no tiene el formato "Bearer ..." se deniega el acceso
+    // Si el header no existe o no empieza con 'Bearer ', el cliente no envió token
+    // Respondemos 401 Unauthorized — el cliente no está identificado
     if (!authHeader || !authHeader.startsWith('Bearer ')) {
         return res.status(401).json({ error: 'Acceso denegado: Token requerido' });
     }
 
-    // Se extrae solo el token (la parte después del espacio de "Bearer ")
+    // authHeader es "Bearer TOKEN" — split(' ')[1] extrae solo el TOKEN
+    // el índice [0] sería "Bearer" y [1] es el token JWT real
     const token = authHeader.split(' ')[1];
 
     try {
-        // jwt.verify lanza un error si el token es inválido o expiró
+        // jwt.verify hace dos cosas a la vez:
+        //   1. Verifica que la firma del token coincida con JWT_SECRET del .env
+        //   2. Verifica que el token no haya expirado (campo exp del payload)
+        // Si cualquiera de las dos falla, lanza un error y va al catch
         const payload = jwt.verify(token, process.env.JWT_SECRET);
 
-        // Se adjunta el payload al request para que los controladores lo usen
-        // Ejemplo de uso en un controlador: const { id, role } = req.usuario;
+        // Si llegamos aquí el token es válido — adjuntamos el payload al request
+        // El payload contiene: { id, documento, role, iat, exp }
+        // Los controladores acceden a req.usuario.id y req.usuario.role
         req.usuario = payload;
 
-        // Token válido — continuar al siguiente middleware o ruta
+        // next() le dice a Express que continúe al siguiente middleware o controlador
+        // Sin llamar a next() la petición quedaría colgada sin respuesta
         next();
 
     } catch (error) {
-        // TokenExpiredError se lanza cuando el tiempo de vida del token venció
+        // TokenExpiredError es el error específico de jsonwebtoken cuando el token expiró
+        // El campo exp del payload venció — el usuario debe hacer login de nuevo
         if (error.name === 'TokenExpiredError') {
             return res.status(401).json({
                 error: 'Acceso denegado: El token ha expirado, inicie sesión nuevamente',
             });
         }
-        // Cualquier otro error: firma inválida, token malformado, etc.
+        // Cualquier otro error significa que el token fue alterado o es inválido
+        // JsonWebTokenError cubre firma incorrecta, token malformado, etc.
         return res.status(401).json({ error: 'Acceso denegado: Token inválido' });
     }
 }
 
-// ── MIDDLEWARE: VERIFICAR QUE EL USUARIO ES ADMIN ────────────────────────────
-// Se usa como segundo middleware en rutas que solo los admin pueden usar.
-// Ejemplo de uso en la ruta: router.patch('/:id/role', verifyToken, requireAdmin, changeUserRole)
+// requireAdmin — middleware que verifica que el usuario autenticado sea admin
+// SIEMPRE se usa DESPUÉS de verifyToken, nunca solo
+// Ejemplo de uso: router.patch('/:id/role', verifyToken, requireAdmin, changeUserRole)
 //
 // verifyToken ya verificó la firma del JWT y adjuntó req.usuario al request.
 // requireAdmin solo verifica que req.usuario.role sea 'admin'.
 //
-// Si el usuario no es admin responde 403 Forbidden con mensaje en español.
-// 403 significa "autenticado pero sin permisos" (distinto de 401 "no autenticado").
+// 403 Forbidden significa "autenticado pero sin permisos"
+// Es distinto a 401 que significa "no autenticado"
 export function requireAdmin(req, res, next) {
 
-    // req.usuario fue adjuntado por verifyToken, que debe ejecutarse primero
-    // Si por alguna razón req.usuario no existe, denegar el acceso
+    // req.usuario fue adjuntado por verifyToken — si no existe algo falló en el orden
+    // Este guard evita un crash si se usa requireAdmin sin verifyToken antes
     if (!req.usuario) {
         return res.status(401).json({ error: 'Acceso denegado: Token requerido' });
     }
 
-    // Verificar que el rol en el payload del JWT sea 'admin'
-    // El role queda en el token al hacer login y no cambia hasta el próximo login
+    // El campo role viene del payload del JWT que se generó en el login
+    // Solo los usuarios con role === 'admin' pueden pasar este guard
     if (req.usuario.role !== 'admin') {
+        // 403 Forbidden: el usuario está autenticado pero no tiene permisos de admin
         return res.status(403).json({
             error: 'Acceso denegado: Se requieren permisos de administrador para esta acción',
         });
     }
 
-    // El usuario es admin — continuar al controlador
+    // El usuario es admin — continuar al controlador de la ruta
     next();
 }

--- a/src/models/task.model.js
+++ b/src/models/task.model.js
@@ -12,74 +12,104 @@
 // pool.query retorna [filas, metadatos] — desestructuramos con [rows]
 // para tomar solo las filas y descartar los metadatos que no necesitamos.
 
+// pool es el grupo de conexiones a MySQL configurado en db.connection.js
+// Reutiliza conexiones existentes en lugar de abrir una nueva por cada query
 import pool from '../database/db.connection.js';
 
 // ── FUNCIONES PRIVADAS DE SERIALIZACIÓN ─────────────────────────────────────
 
-// Convierte arreglo JS a JSON string para guardar en la columna assigned_users.
-// MySQL no tiene tipo array nativo, así que guardamos el JSON como texto.
+// serializarUsuarios — convierte arreglo JS a JSON string para guardar en MySQL
+// MySQL no tiene tipo array nativo, así que los IDs de usuarios asignados
+// se guardan como texto JSON en la columna assigned_users
 // Ejemplo: [1, 2, 3] → '[1,2,3]'
-// Todos los ids se convierten a Number para que la comparación sea consistente.
+// Number(id) garantiza que todos los ids sean números y no strings
 function serializarUsuarios(arreglo) {
+    // Si no llega nada o no es un arreglo, guardar un arreglo vacío
     if (!arreglo || !Array.isArray(arreglo)) return JSON.stringify([]);
+    // map convierte cada id a Number para consistencia antes de serializar
     return JSON.stringify(arreglo.map(id => Number(id)));
 }
 
-// Convierte el valor de la columna assigned_users de MySQL a arreglo JS.
-// MySQL puede retornar el campo ya como arreglo (columna JSON nativa) o como string.
-// El try/catch evita que JSON.parse rompa la aplicación si el valor es inválido.
+// deserializarUsuarios — convierte el valor de la columna assigned_users a arreglo JS
+// MySQL puede retornar el campo ya como arreglo (columna JSON nativa) o como string
+// dependiendo de la versión de mysql2 y la configuración de MySQL
+// El try/catch evita que JSON.parse rompa la aplicación si el valor está malformado
 function deserializarUsuarios(valor) {
+    // Si mysql2 ya lo parseó como arreglo, retornarlo directamente
     if (Array.isArray(valor)) return valor;
-    try { return JSON.parse(valor || '[]'); } catch { return []; }
+    try {
+        // JSON.parse convierte el string '[1,2,3]' al arreglo [1, 2, 3]
+        // Si valor es null o undefined, usamos '[]' como fallback
+        return JSON.parse(valor || '[]');
+    } catch {
+        // Si el JSON está malformado, retornar arreglo vacío en lugar de crashear
+        return [];
+    }
 }
 
-// Formatea una fila de MySQL convirtiendo los nombres de columnas a camelCase
-// y resolviendo el campo assigned_users de JSON a arreglo JS.
+// formatearTarea — convierte una fila raw de MySQL a un objeto con nombres camelCase
+// MySQL usa snake_case (assigned_users, created_at) — el frontend espera camelCase
 // CORRECCIÓN: se agrega el campo 'comment' que faltaba en la versión anterior.
 //   Sin este campo, el frontend enviaba comment al editar una tarea,
 //   pero la respuesta del servidor nunca lo incluía → la tabla mostraba '—' siempre.
-// Parámetro: filaDb — objeto raw devuelto por pool.query (nombres con underscore).
-// Retorna: objeto con nombres camelCase listo para enviar como JSON al frontend.
+//
+// Parámetro: filaDb — objeto raw devuelto por pool.query (nombres con underscore)
+// Retorna: objeto con nombres camelCase listo para enviar como JSON al frontend
 function formatearTarea(filaDb) {
+    // Si filaDb es undefined (tarea no encontrada), retornar null en lugar de crashear
     if (!filaDb) return null;
     return {
+        // Campos que no necesitan transformación de nombre
         id:            filaDb.id,
         title:         filaDb.title,
         description:   filaDb.description,
         status:        filaDb.status,
-        // CORRECCIÓN: campo comment incluido. Usa || null para evitar undefined.
-        // Si la columna es NULL en MySQL, MySQL2 lo devuelve como null de JS.
+        // comment: usa || null para convertir undefined a null de forma explícita
+        // Si la columna es NULL en MySQL, mysql2 lo devuelve como null de JS
         comment:       filaDb.comment || null,
+        // assigned_users (snake_case de MySQL) → assignedUsers (camelCase del frontend)
+        // deserializarUsuarios convierte el JSON string '[1,2,3]' al arreglo [1,2,3]
         assignedUsers: deserializarUsuarios(filaDb.assigned_users),
+        // created_ud (nombre de columna en la BD) → createdAt (camelCase del frontend)
         createdAt:     filaDb.created_ud
     };
 }
 
 // ── FUNCIONES EXPORTADAS (usadas por el controlador) ────────────────────────
 
-// RF03 — READ: retorna todas las tareas con los nombres de usuarios resueltos.
-// Hace un cross-join en memoria entre tareas y usuarios para que el frontend
-// pueda mostrar los nombres en lugar de los IDs numéricos.
-// assignedUsersDisplay: string formateado listo para la columna "Usuario asignado".
+// getAllTasks — retorna todas las tareas con los nombres de usuarios resueltos
+// Se usa en GET /api/tasks (solo admin e instructor pueden ver todas)
+// Hace dos queries: una para tareas y otra para usuarios, luego las combina en memoria
+// assignedUsersDisplay: string formateado listo para mostrar en la tabla del panel
 export async function getAllTasks() {
-    // Se obtienen todas las tareas de la tabla tasks
+    // Query 1: obtener todas las tareas de la tabla tasks
     const [rows]     = await pool.query('SELECT * FROM tasks');
-    // Se obtienen todos los usuarios para resolver los IDs a nombres
+    // Query 2: obtener id, name y documento de todos los usuarios para resolver los IDs
+    // Solo se traen los campos necesarios, no todo el objeto usuario (evita exponer passwords)
     const [usuarios] = await pool.query('SELECT id, name, documento FROM users');
 
+    // Para cada tarea, resolver los IDs de usuarios asignados a nombres legibles
     return rows.map(function(fila) {
-        const tarea   = formatearTarea(fila);
+        // Convertir la fila raw de MySQL al formato camelCase del frontend
+        const tarea = formatearTarea(fila);
 
+        // Resolver cada ID del arreglo assignedUsers al nombre del usuario correspondiente
         const nombres = tarea.assignedUsers.map(function(id) {
+            // find busca en el arreglo de usuarios el que tiene ese id
             const encontrado = usuarios.find(u => u.id === Number(id));
+            // Si el usuario existe retornar su nombre, si fue eliminado retornar null
             return encontrado ? encontrado.name : null;
+        // filter(Boolean) elimina los null del arreglo (usuarios que ya no existen)
         }).filter(Boolean);
 
+        // assignedUsersDisplay: string con los nombres separados por coma
+        // Si no hay usuarios asignados, null (el frontend muestra '—')
         tarea.assignedUsersDisplay = nombres.length > 0 ? nombres.join(', ') : null;
 
-        // assignedDocumentos: permite filtrar por documento en el panel admin
+        // assignedDocumentos: permite al panel admin filtrar por documento de usuario
         tarea.assignedDocumentos = tarea.assignedUsers.map(function(id) {
             const encontrado = usuarios.find(u => u.id === Number(id));
+            // toString() convierte el documento numérico a string para la búsqueda de texto
             return encontrado ? encontrado.documento.toString() : null;
         }).filter(Boolean);
 
@@ -87,27 +117,30 @@ export async function getAllTasks() {
     });
 }
 
-// RF03 — READ: busca una tarea por su id numérico.
-// El ? es un placeholder que mysql2 reemplaza de forma segura (evita SQL injection).
-// Retorna la tarea formateada, o null si no existe.
+// getTaskById — busca una tarea por su id numérico
+// Se usa internamente por casi todas las funciones del modelo
+// El ? es un placeholder que mysql2 reemplaza de forma segura (evita SQL injection)
+// Retorna la tarea formateada, o null si no existe ninguna tarea con ese id
 export async function getTaskById(id) {
     const [rows] = await pool.query(
         'SELECT * FROM tasks WHERE id = ?',
         [Number(id)]
     );
-    // formatearTarea devuelve null si filaDb es undefined (tarea no encontrada)
+    // formatearTarea retorna null si rows[0] es undefined (tarea no encontrada)
     return formatearTarea(rows[0]);
 }
 
-// RF02 — CREATE: inserta una tarea nueva en la tabla tasks.
+// createTask — inserta una tarea nueva en la tabla tasks
 // CORRECCIÓN: se agrega 'comment' al INSERT para persistir el campo en MySQL.
 //   En la versión anterior el INSERT no incluía comment, por lo que siempre
 //   quedaba NULL en la base de datos aunque el frontend lo enviara.
-// Parámetros desestructurados con valores por defecto para campos opcionales:
-//   status       → 'pendiente' si no se especifica
-//   assignedUsers → [] si no se especifica
-//   comment      → null si no se especifica (es opcional)
-// Retorna: el objeto de la tarea recién creada, con el id asignado por MySQL.
+//
+// Los parámetros tienen valores por defecto para los campos opcionales:
+//   status       → 'pendiente' si el frontend no especifica estado
+//   assignedUsers → [] si no se asigna ningún usuario
+//   comment      → null si no se escribe comentario
+//
+// Retorna: el objeto de la tarea recién creada con el id asignado por MySQL
 export async function createTask({
     title,
     description,
@@ -115,114 +148,146 @@ export async function createTask({
     assignedUsers = [],
     comment       = null
 }) {
+    // INSERT con los 5 campos — el orden de los ? debe coincidir con VALUES
     const [result] = await pool.query(
-        // CORRECCIÓN: se agrega la columna 'comment' al INSERT
         'INSERT INTO tasks (title, description, status, assigned_users, comment) VALUES (?, ?, ?, ?, ?)',
         [
             title,
+            // Si description no viene o es cadena vacía, guardar cadena vacía en MySQL
             description || '',
             status,
+            // serializarUsuarios convierte [1,2,3] a '[1,2,3]' para guardar como JSON en MySQL
             serializarUsuarios(assignedUsers),
-            // Si comment es cadena vacía lo convertimos a null para consistencia
+            // Si comment es cadena vacía lo convertimos a null para consistencia en la BD
+            // Una cadena vacía y null son equivalentes semánticamente en este contexto
             comment || null
         ]
     );
-    // result.insertId tiene el id AUTO_INCREMENT que MySQL asignó a la nueva fila
+    // result.insertId contiene el id AUTO_INCREMENT que MySQL asignó a la nueva fila
+    // Se llama a getTaskById para retornar el objeto completo y formateado
     return getTaskById(result.insertId);
 }
 
-// RF03 — UPDATE: actualiza los campos de una tarea existente.
-// CORRECCIÓN: se agrega 'comment' a la lista de campos que se pueden actualizar.
-//   En la versión anterior, aunque el frontend enviara comment al editar,
-//   el modelo lo ignoraba y MySQL nunca guardaba el nuevo valor.
-// Lista blanca de campos permitidos: cualquier otro campo del body se ignora.
-// Retorna: la tarea actualizada, o null si el id no existe.
+// updateTask — actualiza los campos de una tarea existente
+// CORRECCIÓN: se agrega 'comment' a la lista de campos actualizables.
+//   En la versión anterior el modelo ignoraba comment aunque el frontend lo enviara.
+//
+// Solo actualiza los campos que llegaron en el body (undefined = no se envió = no se toca)
+// Retorna: la tarea actualizada, o null si el id no existe
 export async function updateTask(id, campos) {
+    // Verificar que la tarea existe antes de intentar actualizar
     const existente = await getTaskById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!existente) return null;
 
-    // Se construye el objeto de campos a actualizar solo con los permitidos
+    // Construir el objeto con los campos a actualizar en la BD (nombres de columnas MySQL)
     const camposDb = {};
 
-    // Verificamos cada campo permitido y lo incluimos solo si llegó en el body
+    // Verificar campo por campo si llegó en el body (undefined = no enviar)
     if (campos.title         !== undefined) camposDb.title          = campos.title;
     if (campos.description   !== undefined) camposDb.description    = campos.description;
     if (campos.status        !== undefined) camposDb.status         = campos.status;
+    // assignedUsers del frontend → assigned_users en MySQL (snake_case de la BD)
+    // serializarUsuarios convierte el arreglo JS al JSON string que guarda MySQL
     if (campos.assignedUsers !== undefined) camposDb.assigned_users = serializarUsuarios(campos.assignedUsers);
     // CORRECCIÓN: se permite actualizar el campo comment
     // Se convierte cadena vacía a null para que MySQL guarde NULL, no una cadena vacía
     if (campos.comment !== undefined) camposDb.comment = campos.comment || null;
 
-    // Si no llegó ningún campo válido no se ejecuta el UPDATE innecesariamente
+    // Si no llegó ningún campo válido, no ejecutar el UPDATE innecesariamente
+    // Retornar la tarea sin cambios
     if (Object.keys(camposDb).length === 0) return existente;
 
-    // Se construye dinámicamente la parte SET del SQL: "title = ?, status = ?, ..."
+    // Construir dinámicamente la parte SET: "title = ?, status = ?, assigned_users = ?"
+    // map genera ["title = ?", "status = ?"] y join los une con comas
     const parteSet = Object.keys(camposDb).map(c => `${c} = ?`).join(', ');
+
+    // Ejecutar el UPDATE — el spread agrega todos los valores y al final el id del WHERE
     await pool.query(
         `UPDATE tasks SET ${parteSet} WHERE id = ?`,
         [...Object.values(camposDb), Number(id)]
     );
-    // Se retorna la tarea con los datos ya actualizados desde MySQL
+
+    // Retornar la tarea con los datos ya actualizados desde MySQL
     return getTaskById(id);
 }
 
-// RF04 — DELETE: elimina una tarea de la tabla tasks.
-// Primero guarda el objeto para retornarlo como confirmación de lo que se eliminó.
-// Retorna: el objeto de la tarea eliminada, o null si el id no existía.
+// deleteTask — elimina una tarea de la tabla tasks permanentemente
+// Guarda el objeto antes de eliminarlo para retornarlo como confirmación
+// Retorna: el objeto de la tarea eliminada, o null si el id no existía
 export async function deleteTask(id) {
+    // Verificar que la tarea existe antes de intentar eliminar
     const aEliminar = await getTaskById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!aEliminar) return null;
 
+    // DELETE con placeholder seguro — elimina la fila de la tabla tasks
     await pool.query('DELETE FROM tasks WHERE id = ?', [Number(id)]);
+
+    // Retornar el objeto de la tarea antes de que se eliminara como confirmación
     return aEliminar;
 }
 
-// FILTRO — retorna tareas filtradas por estado y/o usuario asignado.
-// Se usa en GET /api/tasks/filter?status=pendiente&userId=1.
-// Filtra en memoria después de cargar todas las tareas con getAllTasks().
+// filterTasks — retorna tareas filtradas por estado y/o usuario asignado
+// Se usa en GET /api/tasks/filter?status=pendiente&userId=1
+// Carga todas las tareas en memoria y luego filtra — funciona bien para volúmenes pequeños
 export async function filterTasks({ status, userId } = {}) {
+    // getAllTasks ya resuelve los nombres de usuarios y agrega assignedUsersDisplay
     let resultado = await getAllTasks();
 
-    // Si llegó status solo se conservan las tareas con ese estado
+    // Si llegó el parámetro status, conservar solo las tareas con ese estado exacto
     if (status) resultado = resultado.filter(t => t.status === status);
-    // Si llegó userId solo se conservan las tareas donde ese id está en assignedUsers
+    // Si llegó userId, conservar solo las tareas donde ese id está en assignedUsers
+    // Number(userId) convierte el string del query param al número del arreglo
     if (userId) resultado = resultado.filter(t => t.assignedUsers.includes(Number(userId)));
 
     return resultado;
 }
 
-// Retorna todas las tareas asignadas a un usuario específico.
-// Se usa en GET /api/users/:userId/tasks.
+// getTasksByUserId — retorna todas las tareas asignadas a un usuario específico
+// Se usa en GET /api/users/:userId/tasks
+// Usa getAllTasks (que ya resuelve nombres) y luego filtra por userId
 export async function getTasksByUserId(userId) {
     const todas = await getAllTasks();
+    // includes verifica si el userId está en el arreglo assignedUsers de cada tarea
     return todas.filter(t => t.assignedUsers.includes(Number(userId)));
 }
 
-// Cambia solo el campo status de una tarea sin tocar los demás campos.
-// Se usa en PATCH /api/tasks/:id/status.
+// updateTaskStatus — cambia solo el campo status de una tarea
+// Se usa en PATCH /api/tasks/:id/status (el usuario cambia el estado de su propia tarea)
+// Llama a updateTask internamente para reutilizar la lógica de validación y retorno
 export async function updateTaskStatus(id, status) {
+    // Se pasa un objeto con solo el campo status para que updateTask actualice únicamente ese campo
     return updateTask(id, { status });
 }
 
-// Agrega usuarios a la lista assignedUsers de una tarea, sin duplicados.
-// Usa Set para eliminar automáticamente los ids que ya estaban en la lista.
-// Se usa en POST /api/tasks/:taskId/assign.
+// assignUsersToTask — agrega usuarios al arreglo assignedUsers de una tarea
+// Usa Set para eliminar automáticamente los IDs duplicados
+// Se usa en POST /api/tasks/:taskId/assign
 export async function assignUsersToTask(taskId, userIds) {
+    // Verificar que la tarea existe antes de modificarla
     const tarea = await getTaskById(taskId);
     if (!tarea) return null;
 
-    // [...new Set(...)] elimina duplicados combinando los existentes y los nuevos
+    // Combinar los usuarios existentes con los nuevos y eliminar duplicados con Set
+    // [...new Set([...arregloA, ...arregloB])] es el patrón estándar para unión sin duplicados
     const nuevosUsuarios = [...new Set([...tarea.assignedUsers, ...userIds.map(Number)])];
+
+    // Actualizar la tarea con el arreglo combinado
     return updateTask(taskId, { assignedUsers: nuevosUsuarios });
 }
 
-// Quita un usuario específico de la lista assignedUsers de una tarea.
-// Se usa en DELETE /api/tasks/:taskId/users/:userId.
+// removeUserFromTask — quita un usuario específico de la lista assignedUsers
+// Se usa en DELETE /api/tasks/:taskId/users/:userId
 export async function removeUserFromTask(taskId, userId) {
+    // Verificar que la tarea existe antes de modificarla
     const tarea = await getTaskById(taskId);
     if (!tarea) return null;
 
-    // filter devuelve todos los ids EXCEPTO el que se quiere eliminar
+    // filter retorna todos los ids EXCEPTO el userId que se quiere quitar
+    // Number(userId) convierte el string del parámetro de ruta al número del arreglo
     const filtrados = tarea.assignedUsers.filter(id => id !== Number(userId));
+
+    // Actualizar la tarea con el arreglo sin el usuario eliminado
     return updateTask(taskId, { assignedUsers: filtrados });
 }

--- a/src/models/user.model.js
+++ b/src/models/user.model.js
@@ -7,177 +7,207 @@
 // pool.query retorna [filas, metadatos] — desestructuramos con [rows]
 // para tomar solo las filas y descartar los metadatos que no necesitamos.
 
+// pool es el objeto de conexión a MySQL creado en db.connection.js
+// Usar un pool (grupo de conexiones) es más eficiente que abrir una conexión nueva
+// por cada petición — el pool reutiliza conexiones existentes automáticamente
 import pool from '../database/db.connection.js';
 
-// campos que se pueden actualizar desde el exterior
-// cualquier otro campo que llegue en el body se ignora silenciosamente
+// Lista blanca de campos que se pueden actualizar desde el exterior
+// Cualquier otro campo que llegue en el body se ignora silenciosamente
+// Esto evita que alguien actualice campos sensibles como 'password' o 'role'
+// a través del endpoint genérico de actualización de usuario
 const CAMPOS_ACTUALIZABLES = ['documento', 'name', 'email'];
 
-// RF03 — READ: retorna todos los usuarios de la tabla users
-// el arreglo completo se usa en GET /api/users
+// getAllUsers — retorna todos los usuarios de la tabla users
+// Se usa en GET /api/users (accesible solo por admin e instructor)
+// SELECT * incluye el campo password — el controlador debe filtrarlo antes de responder
 export async function getAllUsers() {
+    // pool.query retorna [rows, fields] — desestructuramos solo rows (las filas)
+    // fields contiene metadatos de las columnas que no necesitamos
     const [rows] = await pool.query('SELECT * FROM users');
+    // rows es un arreglo de objetos — puede estar vacío si no hay usuarios
     return rows;
 }
 
-// RF03 — READ: busca un usuario por su id numérico
-// el ? es un placeholder que mysql2 reemplaza de forma segura (evita SQL injection)
-// retorna el primer resultado, o undefined si no existe
+// getUserById — busca un usuario por su id numérico
+// Se usa internamente por casi todas las funciones de este módulo
+// El ? es un placeholder que mysql2 reemplaza de forma segura (evita SQL injection)
+// Si mysql2 recibiera el id como string en la query, podría ocurrir inyección SQL
 export async function getUserById(id) {
+    // Number(id) convierte strings a número para que la comparación sea correcta
+    // Sin esto, '1' === 1 falla en JavaScript y la query podría no encontrar el usuario
     const [rows] = await pool.query(
         'SELECT * FROM users WHERE id = ?',
         [Number(id)]
     );
+    // rows[0] es el primer (y único) resultado — undefined si no existe el id
     return rows[0];
 }
 
-// busca un usuario por su número de documento de identidad
-// se usa desde el frontend para buscar por documento
+// getUserByDocumento — busca un usuario por su número de documento de identidad
+// Se usa en registerService para verificar que el documento no esté ya registrado
+// Retorna el usuario encontrado o undefined si no existe
 export async function getUserByDocumento(documento) {
+    // toString() garantiza que el documento llegue como string a la query
+    // aunque el frontend lo envíe como número
     const [rows] = await pool.query(
         'SELECT * FROM users WHERE documento = ?',
         [documento.toString()]
     );
+    // rows[0] es undefined si no hay ningún usuario con ese documento
     return rows[0];
 }
 
-// RF02 — CREATE: inserta un usuario nuevo en la tabla users
-// result.insertId contiene el id AUTO_INCREMENT que MySQL asignó
-// retornamos el usuario completo llamando a getUserById para incluir timestamps
+// createUser — inserta un usuario nuevo en la tabla users (sin password ni role)
+// Se usa desde el panel admin para crear usuarios sin contraseña inicial
+// Para el registro con contraseña, usar createUserWithPassword (más abajo)
+// result.insertId contiene el id AUTO_INCREMENT que MySQL asignó a la nueva fila
 export async function createUser({ documento, name, email }) {
+    // El INSERT solo incluye los 3 campos básicos — password y role quedan con sus defaults de MySQL
     const [result] = await pool.query(
         'INSERT INTO users (documento, name, email) VALUES (?, ?, ?)',
         [documento, name, email]
     );
+    // Se llama a getUserById para retornar el objeto completo con todos los campos
+    // incluyendo created_at, is_active y role que MySQL asigna automáticamente
     return getUserById(result.insertId);
 }
 
-// actualiza los campos de un usuario existente
-// solo se permiten los campos definidos en CAMPOS_ACTUALIZABLES
-// cualquier otro campo que llegue en el body se ignora para evitar corrupción de datos
+// updateUser — actualiza los campos de un usuario existente
+// Solo se permiten los campos definidos en CAMPOS_ACTUALIZABLES
+// Cualquier otro campo que llegue en el body se ignora para evitar corrupción de datos
 export async function updateUser(id, campos) {
+    // Verificar que el usuario existe antes de intentar actualizar
     const existente = await getUserById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!existente) return null;
 
-    // filtra solo los campos permitidos que realmente llegaron en el body
+    // Construir el objeto con solo los campos que están en la lista blanca
+    // y que realmente llegaron en el body (no undefined)
     const camposFiltrados = {};
     for (const campo of CAMPOS_ACTUALIZABLES) {
+        // Solo incluir el campo si llegó en el body (undefined significa que no se envió)
         if (campos[campo] !== undefined) {
             camposFiltrados[campo] = campos[campo];
         }
     }
 
-    // si no hay campos válidos no se ejecuta el UPDATE
+    // Si no hay campos válidos en el body, no ejecutar el UPDATE innecesariamente
+    // Retornamos el usuario sin cambios para no hacer una petición vacía a MySQL
     if (Object.keys(camposFiltrados).length === 0) return existente;
 
+    // Construir dinámicamente la parte SET del SQL: "documento = ?, name = ?, ..."
+    // map genera ["documento = ?", "name = ?"] y join lo une con comas
     const parteSet = Object.keys(camposFiltrados).map(c => `${c} = ?`).join(', ');
+
+    // Los valores van en el mismo orden que las columnas en parteSet
     const valores  = Object.values(camposFiltrados);
 
+    // Ejecutar el UPDATE con los campos filtrados y el id del usuario
     await pool.query(
         `UPDATE users SET ${parteSet} WHERE id = ?`,
+        // El spread agrega los valores de los campos y al final el id del WHERE
         [...valores, Number(id)]
     );
+
+    // Retornar el usuario con los datos ya actualizados desde MySQL
     return getUserById(id);
 }
 
-// ── NUEVA FUNCIÓN: busca usuario por email ───────────────────────────────────
-// GET interno — se usa en loginService y registerService de auth.service.js
-// Antes el login buscaba por documento. Ahora busca por email porque el
-// formulario de login del frontend pide email + contraseña.
-// Retorna el usuario encontrado (con el campo password incluido para bcrypt),
-// o undefined si no existe ningún usuario con ese email.
+// getUserByEmail — busca un usuario por su correo electrónico
+// Se usa en loginService (para verificar credenciales) y en registerService
+// (para verificar que el email no esté ya registrado)
+// Retorna el usuario con el campo password incluido — bcrypt lo necesita para comparar
 export async function getUserByEmail(email) {
-    // La consulta usa un placeholder ? para evitar inyección SQL (mysql2 lo reemplaza)
+    // toLowerCase().trim() normaliza el email para evitar problemas de mayúsculas o espacios
+    // La query usa ? para evitar SQL injection
     const [rows] = await pool.query(
         'SELECT * FROM users WHERE email = ?',
         [email.toString().toLowerCase().trim()]
     );
-    // rows[0] es el primer resultado o undefined si no hay coincidencia
+    // rows[0] es el usuario encontrado o undefined si el email no existe
     return rows[0];
 }
 
-// ── CREAR USUARIO CON CONTRASEÑA Y ROL ───────────────────────────────────────
-// Se usa exclusivamente desde registerService en auth.service.js.
-// La función createUser que ya existe en este archivo no acepta password ni role,
-// por eso se crea esta variante separada para el flujo de registro.
+// createUserWithPassword — crea un usuario con contraseña y rol desde el registro
+// Se usa exclusivamente desde registerService en auth.service.js
+// La función createUser que ya existe no acepta password ni role — por eso existe esta variante
 //
 // Parámetros:
-//   name     — nombre completo del usuario
+//   name      — nombre completo del usuario
 //   documento — número de documento de identidad (solo dígitos)
-//   email    — correo electrónico del usuario
-//   password — contraseña ya hasheada con bcrypt (NUNCA texto plano)
-//   role     — rol del usuario ('user' o 'admin'), por defecto 'user'
-//
-// Retorna el objeto completo del usuario recién creado (incluyendo password
-// para que registerService pueda excluirlo antes de responder al cliente).
+//   email     — correo electrónico del usuario
+//   password  — contraseña ya hasheada con bcrypt (NUNCA texto plano)
+//   role      — rol del usuario ('user' por defecto — solo admin lo cambia después)
 export async function createUserWithPassword({ name, documento, email, password, role = 'user' }) {
-    // INSERT con los 5 campos: los 3 básicos + password hasheada + role
+    // INSERT con los 5 campos: los 3 básicos más la contraseña hasheada y el rol
+    // El orden de los ? debe coincidir exactamente con el orden del INSERT
     const [result] = await pool.query(
         'INSERT INTO users (name, documento, email, password, role) VALUES (?, ?, ?, ?, ?)',
         [name, documento, email, password, role]
     );
     // result.insertId es el id AUTO_INCREMENT que MySQL asignó a la nueva fila
-    // Se usa getUserById (ya existe en este archivo) para retornar el objeto completo
+    // Se usa getUserById para retornar el objeto completo incluyendo created_at e is_active
     return getUserById(result.insertId);
 }
 
-// elimina un usuario de la tabla users
-// primero guarda el objeto para retornarlo y confirmar qué se eliminó
+// deleteUser — elimina un usuario de la tabla users permanentemente
+// Primero guarda el objeto para retornarlo como confirmación de lo que se eliminó
+// El controlador usa este objeto para responder con los datos del usuario eliminado
 export async function deleteUser(id) {
+    // Verificar que el usuario existe antes de intentar eliminar
     const aEliminar = await getUserById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!aEliminar) return null;
 
+    // DELETE con placeholder seguro — elimina la fila de la tabla users
     await pool.query('DELETE FROM users WHERE id = ?', [Number(id)]);
+
+    // Retornamos el objeto del usuario antes de que se eliminara
+    // El controlador lo envía como respuesta para confirmar qué se borró
     return aEliminar;
 }
 
-// ── ACTUALIZAR ROL DE USUARIO ────────────────────────────────────────────────
-// Se usa desde changeUserRole en users.controller.js.
-// Solo actualiza el campo 'role', no toca ningún otro dato del usuario.
+// updateUserRole — actualiza solo el campo role de un usuario
+// Se usa desde changeUserRole en users.controller.js (PATCH /api/users/:id/role)
+// Solo modifica el campo role — no toca ningún otro dato del usuario
 //
 // Parámetros:
 //   id   — id numérico del usuario a modificar
-//   role — nuevo rol: 'admin' o 'user' (validado en el schema antes de llegar aquí)
-//
-// Retorna el usuario actualizado sin el campo password,
-// o null si el id no existe en la tabla users.
+//   role — nuevo rol: 'admin', 'instructor' o 'user' (validado por Zod antes de llegar aquí)
 export async function updateUserRole(id, role) {
     // Verificar que el usuario existe antes de intentar actualizar
     const existente = await getUserById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!existente) return null;
 
-    // UPDATE solo modifica el campo role, no el updated_up timestamp
+    // UPDATE solo modifica el campo role — ningún otro campo del usuario se toca
     // mysql2 reemplaza los ? por los valores de forma segura (evita SQL injection)
     await pool.query(
         'UPDATE users SET role = ? WHERE id = ?',
         [role, Number(id)]
     );
 
-    // Retornar el usuario con los datos actualizados desde MySQL
-    // getUserById incluye todos los campos excepto que el controlador los filtre
+    // Retornar el usuario con el rol ya actualizado desde MySQL
     return getUserById(id);
 }
 
-// ── OBTENER ROLES Y PERMISOS DE UN USUARIO (RBAC) ────────────────────────────
-// Se usa en el middleware authorization.middleware.js para verificar permisos.
-// También se usa en loginService para devolver los roles al frontend tras el login.
-
-// Consulta las 4 tablas RBAC en una sola query con JOINs:
-//   users → user_roles → roles → role_permissions → permissions
-
+// getUserRolesAndPermissions — obtiene los roles y permisos RBAC de un usuario
+// Se usa en loginService (para incluirlos en la respuesta del login)
+// y en authorization.middleware.js (para verificar permisos en rutas protegidas)
+//
 // Parámetro: userId — id numérico del usuario
-
-// Retorna un arreglo de objetos con la estructura:
-//   [{ name: 'admin', permissions: ['tasks.create', 'users.delete', ...] }, ...]
-
-// Si el usuario no tiene roles en la tabla user_roles, retorna un arreglo vacío [].
-// Esto puede pasar con usuarios registrados antes de ejecutar rbac.sql.
+// Retorna: arreglo de objetos [{ name: 'admin', permissions: ['tasks.create', ...] }]
+// Si el usuario no tiene roles en user_roles, retorna []
 export async function getUserRolesAndPermissions(userId) {
- 
-    // La query une las 4 tablas RBAC con LEFT JOINs para que si un rol
-    // no tiene permisos asignados, igual aparezca en el resultado (con permission NULL).
-    // El LEFT JOIN en role_permissions y permissions garantiza que roles sin permisos
-    // también se incluyan en la respuesta en lugar de desaparecer del resultado.
+
+    // La query une las 4 tablas RBAC con INNER JOIN y LEFT JOINs:
+    //   user_roles: vincula usuario con su rol
+    //   roles: nombre del rol (admin, instructor, user)
+    //   role_permissions: vincula rol con sus permisos (puede no existir → LEFT JOIN)
+    //   permissions: código del permiso (tasks.create, users.delete, etc.) (LEFT JOIN)
+    // LEFT JOIN en role_permissions y permissions garantiza que roles sin permisos
+    // igual aparezcan en el resultado (con permissionCode = NULL) en vez de desaparecer
     const [rows] = await pool.query(
         `SELECT
             r.name        AS roleName,
@@ -190,62 +220,60 @@ export async function getUserRolesAndPermissions(userId) {
         ORDER BY r.name, p.code`,
         [Number(userId)]
     );
- 
-    // Si el usuario no tiene roles en user_roles, retornar arreglo vacío
+
+    // Si el resultado está vacío, el usuario no tiene filas en user_roles
+    // Esto puede pasar con usuarios creados antes de ejecutar rbac.sql
     if (rows.length === 0) return [];
- 
-    // Agrupar los resultados por nombre de rol, acumulando sus permisos en un arreglo.
-    // rows puede tener múltiples filas con el mismo roleName (una por cada permiso).
+
+    // Agrupar las filas por nombre de rol, acumulando sus permisos en un arreglo
+    // rows tiene múltiples filas con el mismo roleName (una por cada permiso)
     // Necesitamos convertirlas a: [{ name: 'admin', permissions: ['tasks.create', ...] }]
     const rolesMap = {};
- 
+
     rows.forEach(function(fila) {
-        // Si este rol no está en el mapa todavía, creamos su entrada
+        // Si este rol todavía no está en el mapa, crear su entrada con arreglo vacío
         if (!rolesMap[fila.roleName]) {
             rolesMap[fila.roleName] = {
                 name:        fila.roleName,
                 permissions: [],
             };
         }
-        // Si tiene un permiso asignado (puede ser NULL si el rol no tiene permisos),
-        // lo agregamos al arreglo de permisos del rol
+        // Solo agregar el permiso si no es NULL (roles sin permisos tienen permissionCode = null)
         if (fila.permissionCode) {
             rolesMap[fila.roleName].permissions.push(fila.permissionCode);
         }
     });
- 
-    // Object.values convierte el mapa de objetos a un arreglo de roles
+
+    // Object.values convierte el mapa { admin: {...}, user: {...} } a un arreglo de objetos
     return Object.values(rolesMap);
 }
 
-// ── ACTUALIZAR CONTRASEÑA DE USUARIO ─────────────────────────────────────────
-// Se usa desde:
+// updateUserPassword — actualiza solo el campo password de un usuario
+// Se usa en:
 //   1. PATCH /api/users/:id/password (cambio de contraseña desde el panel)
 //   2. POST /api/auth/reset-password (restablecimiento por código de Mailtrap)
-
+//
 // Parámetro: id — id numérico del usuario
 // Parámetro: nuevaPasswordHasheada — contraseña ya hasheada con bcrypt (NUNCA texto plano)
-
-// Retorna: el usuario actualizado, o null si el id no existe.
 export async function updateUserPassword(id, nuevaPasswordHasheada) {
     // Verificar que el usuario existe antes de intentar actualizar
     const existente = await getUserById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!existente) return null;
- 
-    // Solo actualiza la columna password — ningún otro campo se toca
+
+    // Solo actualiza la columna password — ningún otro campo del usuario se toca
     await pool.query(
         'UPDATE users SET password = ? WHERE id = ?',
         [nuevaPasswordHasheada, Number(id)]
     );
- 
-    // Retornar el usuario con los datos actualizados
+
+    // Retornar el usuario con los datos actualizados desde MySQL
     return getUserById(id);
 }
 
-// ── DESACTIVAR USUARIO (DESACTIVACIÓN LÓGICA) ────────────────────────────────
-// Se usa desde el controlador deactivateUser en users.controller.js.
-// No elimina el usuario de la BD — solo cambia is_active a 0.
-// Esto preserva todas las tareas asociadas al usuario.
+// deactivateUser — desactivación lógica del usuario (is_active = 0)
+// No elimina el usuario de la BD — preserva todas sus tareas y datos históricos
+// Se usa desde deactivateUser en users.controller.js (PATCH /api/users/:id/deactivate)
 //
 // Parámetro: id — id numérico del usuario a desactivar
 // Retorna: el usuario actualizado con is_active = 0, o null si no existe
@@ -255,8 +283,8 @@ export async function deactivateUser(id) {
     // Si no existe retornamos null para que el controlador responda 404
     if (!existente) return null;
 
-    // UPDATE solo modifica is_active — no toca ningún otro campo del usuario
-    // El ? es el placeholder seguro de mysql2 (evita inyección SQL)
+    // UPDATE solo modifica is_active = 0 — no toca ningún otro campo del usuario
+    // El ? es el placeholder seguro de mysql2 que evita SQL injection
     await pool.query(
         'UPDATE users SET is_active = 0 WHERE id = ?',
         [Number(id)]
@@ -266,20 +294,17 @@ export async function deactivateUser(id) {
     return getUserById(id);
 }
 
-// ── CONTAR TAREAS PENDIENTES O EN PROGRESO DE UN USUARIO ─────────────────────
-// Se usa en el controlador deactivateUser para validar la regla de negocio:
-// "un usuario no puede desactivarse si tiene tareas pendientes o en progreso".
+// countUserActiveTasks — cuenta cuántas tareas activas tiene un usuario
+// Se usa en deactivateUser del controlador para verificar la regla de negocio:
+// "no se puede desactivar un usuario con tareas pendientes o en progreso"
 //
 // Parámetro: userId — id numérico del usuario
-// Retorna: número de tareas activas (pendiente + en_progreso) del usuario
-//
-// NOTA: la tabla tasks guarda assigned_users como JSON (ej: "[1, 2, 3]").
-// Usamos JSON_CONTAINS para buscar el id del usuario dentro del JSON sin
-// tener que traer todos los registros a Node y filtrar en memoria.
+// Retorna: número entero con la cantidad de tareas activas (0 = puede desactivarse)
 export async function countUserActiveTasks(userId) {
-    // JSON_CONTAINS(columna, valor, ruta) verifica si el JSON contiene el valor
+    // JSON_CONTAINS(columna, valor, ruta) busca un valor dentro de un campo JSON
+    // La columna assigned_users guarda los ids como JSON: "[1, 2, 3]"
     // CAST(? AS JSON) convierte el id numérico a JSON para que la comparación funcione
-    // Se filtran solo los estados que bloquean la desactivación
+    // Sin CAST, MySQL no podría comparar el número con el array JSON correctamente
     const [rows] = await pool.query(
         `SELECT COUNT(*) AS total
          FROM tasks
@@ -287,22 +312,26 @@ export async function countUserActiveTasks(userId) {
            AND JSON_CONTAINS(assigned_users, CAST(? AS JSON), '$')`,
         [Number(userId)]
     );
-    // rows[0].total es el número de tareas activas — 0 significa que puede desactivarse
+    // rows[0].total es el COUNT — 0 significa que el usuario puede desactivarse
     return rows[0].total;
 }
 
-// ── REACTIVAR USUARIO ─────────────────────────────────────────────────────────
-// Operación inversa a deactivateUser — cambia is_active de 0 a 1.
-// Solo el admin puede ejecutar esta acción (requireAdmin en la ruta).
-// Retorna el usuario actualizado, o null si el id no existe.
+// reactivateUser — reactiva un usuario desactivado (is_active = 0 → 1)
+// Operación inversa a deactivateUser
+// Solo el admin puede ejecutar esta acción (requireAdmin en la ruta)
+// Retorna el usuario actualizado, o null si el id no existe
 export async function reactivateUser(id) {
+    // Verificar que el usuario existe antes de intentar actualizar
     const existente = await getUserById(id);
+    // Si no existe retornamos null para que el controlador responda 404
     if (!existente) return null;
 
+    // UPDATE solo modifica is_active = 1 — el usuario puede volver a iniciar sesión
     await pool.query(
         'UPDATE users SET is_active = 1 WHERE id = ?',
         [Number(id)]
     );
 
+    // Retornar el usuario con is_active = 1 para confirmar la reactivación
     return getUserById(id);
 }


### PR DESCRIPTION
## Descripción del Cambio
Este PR agrupa los cambios del lado del servidor y la capa de API del Milestone 12. Se añadieron las funciones `desactivarUsuario()` y `reactivarUsuario()` en `usuariosApi.js` para consumir los endpoints `PATCH /api/users/:id/deactivate` y `PATCH /api/users/:id/reactivate`. Se corrigieron las claves foráneas de `rbac.sql`, cambiando `ON DELETE CASCADE` a `ON DELETE RESTRICT` en las tablas `role_permissions` y `user_roles` para proteger la integridad referencial. Además, se documentaron con comentarios línea por línea los archivos `fetchConAuth.js`, `auth.middleware.js`, `user.model.js`, `task.model.js` y `auth.service.js`.

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [x] **fix**: Corrección de error.
- [x] **docs / style**: Documentación o formato.
- [x] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #110 
**Vínculo:** Closes #116 

---

## Checklist de Calidad Universal
- [x] Rama actualizada con `origin/release` antes de crear el PR
- [x] Sin `console.log` ni `element.style.X` no permitidos
- [x] Endpoints probados en Postman con token válido de admin
- [x] FK de `rbac.sql` probadas: MySQL rechaza eliminaciones en cascada
- [x] Sin errores en consola del navegador
- [x] Panel de calificación aprueba tareas correctamente
- [x] Dropdown del instructor muestra avatares iguales al del admin
- [x] Buscador del instructor ya no recarga la página al dar Enter
- [x] Tabla de usuarios del admin muestra columnas Rol y Estado con badges

### Validación FRONTEND (Si aplica)
- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).

### Validación BACKEND (Si aplica)
- [x] **Endpoints:** Se probaron `PATCH /api/users/:id/deactivate` y `PATCH /api/users/:id/reactivate` en Postman/Thunder Client y retornan el código HTTP correcto (200 éxito / 400 regla de negocio / 404 no encontrado).
- [x] **Validación:** Se implementó manejo de errores (try/catch) en `desactivarUsuario()` y `reactivarUsuario()` — el mensaje del backend se propaga al frontend correctamente.
- [x] **Modelos:** Los cambios en `rbac.sql` fueron comunicados al equipo y la query de verificación confirma `DELETE_RULE = 'RESTRICT'` en las 4 FK.

---

## Evidencia de Trabajo
<img width="1284" height="231" alt="image" src="https://github.com/user-attachments/assets/91b9c570-5dec-415e-8795-c7325d338e12" />
<img width="983" height="884" alt="image" src="https://github.com/user-attachments/assets/cdbf3e0a-7f59-424d-bf66-1f37e6646e93" />
<img width="1068" height="905" alt="image" src="https://github.com/user-attachments/assets/b68e30aa-4195-4ad0-893f-132d23741806" />
<img width="997" height="872" alt="image" src="https://github.com/user-attachments/assets/f85a2974-c10b-4076-a263-80035ca1fac9" />
<img width="924" height="882" alt="image" src="https://github.com/user-attachments/assets/db2ece7e-a813-44cb-83a6-9acad912bc48" />

## Archivos Modificados
- `src/api/usuariosApi.js` — agregar `desactivarUsuario()` y `reactivarUsuario()` al final del archivo
- `database/rbac.sql` — cambiar FK de `role_permissions` y `user_roles` de `CASCADE` a `RESTRICT`
- `src/utils/fetchConAuth.js` — comentarios línea por línea (flujo Silent Refresh)
- `src/middlewares/auth.middleware.js` — comentarios línea por línea (middleware `verifyToken`)
- `src/models/user.model.js` — comentarios línea por línea (`getAllUsers`)
- `src/models/task.model.js` — comentarios línea por línea (funciones del modelo)
- `src/services/auth.service.js` — comentarios línea por línea (generación de tokens)