### PR TITLE
feat: implementación completa del backend — usuarios, calificaciones, calendario y notas

### DIFF
--- a/database/schema.sql
+++ b/database/schema.sql
@@ -2,58 +2,155 @@
 -- ARCHIVO: database/schema.sql
 -- PROYECTO: servidor_backend_parejas - Sistema de Gestión de Tareas
 -- AUTORES: Karol Torres y Sebastian Patiño
--- SENA - Técnico en Programación de Software
+-- SENA: Técnico en Programación de Software
 -- ============================================================
 -- INSTRUCCIONES:
--- Este archivo lo ejecutan con la conexión app_user en Workbench.
--- Antes, ejecuten el bloque en la conexion de root (SI NO LO HAN HECHO YA):
-
--- CREATE DATABASE IF NOT EXISTS gestion_tareas_sena;
--- CREATE USER IF NOT EXISTS 'app_user'@'localhost' IDENTIFIED BY 'TORRES_2007';
--- GRANT ALL PRIVILEGES ON gestion_tareas_sena.* TO 'app_user'@'localhost';
--- FLUSH PRIVILEGES;
+-- 1. Ejecutar primero el bloque de root (solo una vez, si no se ha hecho):
+--
+--    CREATE DATABASE IF NOT EXISTS gestion_tareas_sena;
+--    CREATE USER IF NOT EXISTS 'app_user'@'localhost' IDENTIFIED BY 'TORRES_2007';
+--    GRANT ALL PRIVILEGES ON gestion_tareas_sena.* TO 'app_user'@'localhost';
+--    FLUSH PRIVILEGES;
+--
+-- 2. Ejecutar este archivo completo con la conexión app_user en Workbench.
 -- ============================================================
 
--- Selecciona la base de datos del proyecto (en conexion de app_user)
 USE gestion_tareas_sena;
 
 -- ============================================================
 -- TABLA: users
--- documento UNIQUE: evita registrar la misma persona dos veces
--- password: hash bcrypt de la contraseña (nunca texto plano)
--- role: 'admin' para administradores, 'user' para usuarios normales, 'instructor' para docentes
+--
+-- documento:           número de documento único por persona
+-- password:            hash bcrypt (nunca texto plano)
+-- role:                'admin' | 'instructor' | 'user'
+-- is_active:           1 = activo, 0 = desactivado (soft delete)
+-- deactivation_reason: motivo registrado al desactivar (issue P1)
+-- deactivation_date:   fecha en que se desactivÃ³ (issue P1)
 -- ============================================================
 CREATE TABLE IF NOT EXISTS users (
-    id          INT          NOT NULL AUTO_INCREMENT,
-    documento   VARCHAR(20)  NOT NULL UNIQUE,
-    name        VARCHAR(100) NOT NULL,
-    email       VARCHAR(100) NOT NULL,
-    password    VARCHAR(255) NULL,
-    role        VARCHAR(20)  NOT NULL DEFAULT 'user',
-    -- is_active: controla si el usuario puede ingresar al sistema
-    -- 1 = activo (puede iniciar sesión), 0 = desactivado (login bloqueado)
-    -- DEFAULT 1 garantiza que todos los usuarios nuevos empiezan activos
-    is_active   TINYINT(1)  NOT NULL DEFAULT 1,
-    created_ud  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
-    updated_up  TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    id                   INT          NOT NULL AUTO_INCREMENT,
+    documento            VARCHAR(20)  NOT NULL UNIQUE,
+    name                 VARCHAR(100) NOT NULL,
+    email                VARCHAR(100) NOT NULL,
+    password             VARCHAR(255) NULL,
+    role                 VARCHAR(20)  NOT NULL DEFAULT 'user',
+    is_active            TINYINT(1)   NOT NULL DEFAULT 1,
+    deactivation_reason  TEXT         NULL     DEFAULT NULL,
+    deactivation_date    TIMESTAMP    NULL     DEFAULT NULL,
+    created_ud           TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    updated_up           TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
     PRIMARY KEY (id)
 );
 
 -- ============================================================
 -- TABLA: tasks
--- assigned_users: arreglo de IDs guardado como JSON (sin FK externa)
--- comment: campo opcional para que el usuario anote observaciones
+--
+-- assigned_users:      arreglo JSON de IDs de usuarios asignados [1, 3, 5]
+-- comment:             comentario libre del usuario sobre la tarea
+-- grade:               nota numérica 0-100 asignada por el instructor (NULL = sin calificar)
+-- grade_reason:        motivo de la última edición de nota (obligatorio al editar nota)
+-- deleted_user_names:  mapa JSON { "userId": "nombre" } que preserva el nombre
+--                      de usuarios eliminados permanentemente antes de borrarlos,
+--                      para que las tareas sigan mostrando a quien estaban asignadas
 -- status valores válidos:
---   pendiente | en_progreso | pendiente_aprobacion | completada
+--   pendiente | en_progreso | pendiente_aprobacion | completada | reprobada
 -- ============================================================
 CREATE TABLE IF NOT EXISTS tasks (
-    id              INT          NOT NULL AUTO_INCREMENT,
-    title           VARCHAR(200) NOT NULL,
-    description     TEXT,
-    status          VARCHAR(30)  NOT NULL DEFAULT 'pendiente',
-    comment         TEXT         NULL,
-    assigned_users  JSON         NOT NULL DEFAULT (JSON_ARRAY()),
-    created_ud      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
-    updated_up      TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    id                  INT          NOT NULL AUTO_INCREMENT,
+    title               VARCHAR(200) NOT NULL,
+    description         TEXT         NULL,
+    status              VARCHAR(30)  NOT NULL DEFAULT 'pendiente',
+    comment             TEXT         NULL,
+    grade               DECIMAL(5,2) NULL     DEFAULT NULL,
+    grade_reason        TEXT         NULL     DEFAULT NULL,
+    assigned_users      JSON         NOT NULL DEFAULT (JSON_ARRAY()),
+    deleted_user_names  JSON         NULL     DEFAULT (JSON_OBJECT()),
+    created_ud          TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    updated_up          TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
     PRIMARY KEY (id)
+);
+
+-- ============================================================
+-- TABLA: calendar_events
+--
+-- Eventos del calendario creados por el instructor o el usuario.
+-- Dos tipos de evento:
+--   'propio'      recordatorio personal (sin estudiante asignado)
+--   'estudiante'  asignado a un estudiante; aparece en su calendario
+--                  en modo solo lectura (sin botÃ³n eliminar)
+--
+-- instructor_id: FK al usuario que crea el evento
+--                (puede ser el instructor o el propio usuario para eventos propios)
+-- student_id:    FK al estudiante asignado (NULL si es evento propio)
+-- task_id:       FK a la tarea relacionada (NULL si no aplica)
+-- date:          fecha del evento (YYYY-MM-DD)
+-- color:         hex del color visible en el calendario
+--   índigo  #6366f1 evento propio del instructor o del usuario
+--   celeste #0ea5e9 evento asignado a un estudiante
+-- tipo:          'propio' | 'estudiante'
+--
+-- Reglas de eliminaciÃ³n:
+--   Si se elimina el instructor - sus eventos se eliminan en cascada
+--   Si se elimina el estudiante - el evento queda sin asignar (NULL)
+--   Si se elimina la tarea      - el evento queda sin tarea (NULL)
+-- ============================================================
+CREATE TABLE IF NOT EXISTS calendar_events (
+    id             INT          NOT NULL AUTO_INCREMENT,
+    instructor_id  INT          NOT NULL,
+    student_id     INT          NULL     DEFAULT NULL,
+    task_id        INT          NULL     DEFAULT NULL,
+    date           DATE         NOT NULL,
+    title          VARCHAR(200) NOT NULL,
+    color          VARCHAR(20)  NOT NULL DEFAULT '#3b82f6',
+    tipo           VARCHAR(20)  NOT NULL DEFAULT 'propio',
+    created_ud     TIMESTAMP    DEFAULT CURRENT_TIMESTAMP,
+    updated_up     TIMESTAMP    DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+
+    -- Buscar eventos por instructor + fecha (consulta más frecuente del panel instructor)
+    INDEX idx_calendar_instructor_date (instructor_id, date),
+
+    -- Buscar eventos por estudiante + fecha (consulta del panel usuario)
+    INDEX idx_calendar_student_date (student_id, date),
+
+    CONSTRAINT fk_calendar_instructor
+        FOREIGN KEY (instructor_id) REFERENCES users(id) ON DELETE CASCADE,
+
+    CONSTRAINT fk_calendar_student
+        FOREIGN KEY (student_id) REFERENCES users(id) ON DELETE SET NULL,
+
+    CONSTRAINT fk_calendar_task
+        FOREIGN KEY (task_id) REFERENCES tasks(id) ON DELETE SET NULL
+);
+
+-- ============================================================
+-- TABLA: user_notes
+--
+-- Notas personales del usuario (migradas de localStorage al servidor).
+-- Cada nota pertenece a un único usuario y tiene texto libre y color pastel.
+-- Al eliminar el usuario, sus notas se eliminan automáticamente (CASCADE).
+--
+-- color valores tí­picos usados por el frontend:
+--   #fef3c7 amarillo pastel
+--   #fce7f3 rosa pastel
+--   #d1fae5 verde pastel
+--   #dbeafe celeste pastel
+-- ============================================================
+CREATE TABLE IF NOT EXISTS user_notes (
+    id         INT         NOT NULL AUTO_INCREMENT,
+    user_id    INT         NOT NULL,
+    texto      TEXT        NOT NULL,
+    color      VARCHAR(20) NOT NULL DEFAULT '#fef3c7',
+    created_at TIMESTAMP   DEFAULT CURRENT_TIMESTAMP,
+
+    PRIMARY KEY (id),
+
+    -- Acelera la consulta GET /api/notes (siempre filtrada por user_id)
+    INDEX idx_user_notes_user (user_id),
+
+    CONSTRAINT fk_user_notes_user
+        FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE
 );

--- a/postman/SISTEMA GESTIÓN DE TAREAS — v2.postman_collection.json
+++ b/postman/SISTEMA GESTIÓN DE TAREAS — v2.postman_collection.json
@@ -1,8 +1,8 @@
 {
   "info": {
-    "_postman_id": "dc5b5aeb-c410-4357-8fc9-1c20e744a1c6",
-    "name": "SISTEMA GESTIÓN DE TAREAS",
-    "description": "Colección actualizada — Autenticación, RBAC, Recuperación de contraseña, Usuarios, Tareas",
+    "_postman_id": "c14e7c03-03bd-4be3-ac47-16146887d332",
+    "name": "SISTEMA GESTIÓN DE TAREAS — v2",
+    "description": "Colección actualizada — Autenticación, RBAC, Recuperación de contraseña, Usuarios, Tareas, Calendario de Eventos, Notas Personales.\n\nNuevos grupos en esta versión:\n• CALENDARIO — 6 endpoints (GET instructor, GET usuario, POST propio, POST estudiante, POST con tarea, DELETE)\n• NOTAS — 4 endpoints (GET, POST, POST sin color, DELETE)\n\nEndpoints actualizados:\n• USUARIOS: Eliminar Forzoso, Desactivar con motivo, Reactivar\n• TAREAS: calificación con grade + gradeReason, estado reprobada, dashboard, filter",
     "schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
     "_exporter_id": "52923475"
   },
@@ -471,7 +471,42 @@
           "response": []
         },
         {
-          "name": "DESACTIVAR USUARIO",
+          "name": "ELIMINAR USUARIO FORZOSO",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reason\": \"El usuario incumplió las normas del programa reiteradamente\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/users/5/force",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "users",
+                "5",
+                "force"
+              ]
+            },
+            "description": "Eliminación permanente incluso si el usuario está activo.\nRequiere body.reason ≥ 10 caracteres.\nAntes de borrar, preserva el nombre en deleted_user_names de las tareas asignadas.\n\n400 si reason está ausente o < 10 chars.\n404 si el usuario no existe."
+          },
+          "response": []
+        },
+        {
+          "name": "DESACTIVAR USUARIO (con motivo)",
           "request": {
             "method": "PATCH",
             "header": [
@@ -481,6 +516,15 @@
                 "type": "text"
               }
             ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reason\": \"Incumplimiento del reglamento académico\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
             "url": {
               "raw": "{{URL_API}}/users/5/deactivate",
               "host": [
@@ -491,7 +535,8 @@
                 "5",
                 "deactivate"
               ]
-            }
+            },
+            "description": "Desactiva al usuario (is_active = 0).\nAcepta body.reason opcional (mínimo 10 chars) — se persiste en deactivation_reason.\n\nImplementación de la issue P1.\n\n400 si el usuario ya está inactivo.\n400 si tiene tareas activas (pendiente / en_progreso)."
           },
           "response": []
         },
@@ -506,6 +551,15 @@
                 "type": "text"
               }
             ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"reason\": \"Situación resuelta, usuario autorizado para continuar\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
             "url": {
               "raw": "{{URL_API}}/users/5/reactivate",
               "host": [
@@ -516,7 +570,8 @@
                 "5",
                 "reactivate"
               ]
-            }
+            },
+            "description": "Reactiva al usuario (is_active = 1).\nLimpia deactivation_reason y deactivation_date.\n\n400 si el usuario ya está activo."
           },
           "response": []
         }
@@ -727,6 +782,158 @@
             }
           },
           "response": []
+        },
+        {
+          "name": "DASHBOARD (todas las tareas)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/tasks/dashboard",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "tasks",
+                "dashboard"
+              ]
+            },
+            "description": "Devuelve conteos globales: total, pendientes, enProgreso, aprobacion, completadas, reprobadas.\n\nUsado por el panel Admin. El panel Instructor filtra por rol en frontend.\nEl panel Usuario recibe las tareas del usuario directamente (no usa este endpoint)."
+          },
+          "response": []
+        },
+        {
+          "name": "FILTRAR TAREAS POR USUARIO",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/tasks/filter",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "tasks",
+                "filter"
+              ]
+            },
+            "description": "GET /api/tasks/filter?userId=3\n\nDevuelve solo las tareas asignadas al userId especificado.\n\nUsar la variable de entorno o cambiar el query param manualmente."
+          },
+          "response": []
+        },
+        {
+          "name": "ACTUALIZAR TAREA CON CALIFICACIÓN",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"title\": \"PRUEBA 1\",\n  \"status\": \"completada\",\n  \"grade\": 85,\n  \"gradeReason\": \"Excelente manejo de los temas tratados\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/tasks/1",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "tasks",
+                "1"
+              ]
+            },
+            "description": "Califica una tarea pasando grade (0–100) y gradeReason (motivo obligatorio al editar nota).\n\ngrade < 70  → status debe ser 'reprobada'\ngrade >= 70 → status debe ser 'completada'\n\nNuevos campos en esta milestone: grade (DECIMAL 5,2) y grade_reason (TEXT)."
+          },
+          "response": []
+        },
+        {
+          "name": "ACTUALIZAR TAREA — SOLO ESTADO (usuario)",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"pendiente_aprobacion\",\n  \"comment\": \"Terminé la tarea\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/tasks/1",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "tasks",
+                "1"
+              ]
+            },
+            "description": "El usuario entrega la tarea cambiando el estado a pendiente_aprobacion.\nSin grade ni gradeReason — solo el instructor puede calificar."
+          },
+          "response": []
+        },
+        {
+          "name": "ACTUALIZAR TAREA — REPROBADA",
+          "request": {
+            "method": "PUT",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"status\": \"reprobada\",\n  \"grade\": 45,\n  \"gradeReason\": \"No cumplió con los requisitos mínimos del ejercicio\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/tasks/1",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "tasks",
+                "1"
+              ]
+            },
+            "description": "Quinta estado del sistema: reprobada.\ngrade < 70 activa este estado automáticamente desde el panel instructor.\n\nVerifica que task.schema.js acepta 'reprobada' en ESTADOS_VALIDOS."
+          },
+          "response": []
         }
       ]
     },
@@ -883,6 +1090,307 @@
           "response": []
         }
       ]
+    },
+    {
+      "name": "CALENDARIO",
+      "item": [
+        {
+          "name": "OBTENER EVENTOS DEL INSTRUCTOR",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/calendar/instructor",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "calendar",
+                "instructor"
+              ]
+            },
+            "description": "Devuelve todos los eventos creados por el instructor autenticado.\nIncluye eventos propios (tipo='propio') y eventos para estudiantes (tipo='estudiante').\n\nCada evento incluye studentName y taskTitle si aplican."
+          },
+          "response": []
+        },
+        {
+          "name": "OBTENER EVENTOS DEL USUARIO (estudiante)",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/calendar/usuario",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "calendar",
+                "usuario"
+              ]
+            },
+            "description": "Devuelve todos los eventos visibles para el estudiante autenticado:\n1. Eventos que el instructor le asignó (student_id = userId)\n2. Eventos propios creados por el estudiante (instructor_id = userId AND tipo='propio')\n\nEl campo instructorId en cada evento permite al frontend saber si el usuario puede eliminarlo."
+          },
+          "response": []
+        },
+        {
+          "name": "CREAR EVENTO PROPIO (instructor o usuario)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-05-15\",\n  \"title\": \"Revisión de avances del proyecto\",\n  \"tipo\": \"propio\",\n  \"color\": \"#6366f1\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/calendar",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "calendar"
+              ]
+            },
+            "description": "Crea un recordatorio personal.\ntipo='propio' → sin studentId.\ncolor sugerido para eventos propios: #6366f1 (índigo).\n\n400 si faltan date, title o tipo."
+          },
+          "response": []
+        },
+        {
+          "name": "CREAR EVENTO PARA ESTUDIANTE",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-05-20\",\n  \"title\": \"Entrega del módulo 3\",\n  \"tipo\": \"estudiante\",\n  \"studentId\": 3,\n  \"color\": \"#0ea5e9\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/calendar",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "calendar"
+              ]
+            },
+            "description": "Crea un evento asignado a un estudiante específico.\ntipo='estudiante' → studentId obligatorio.\ncolor sugerido para eventos de estudiante: #0ea5e9 (celeste).\n\nEl estudiante verá este evento en su propio calendario en modo lectura.\n\n400 si tipo='estudiante' y falta studentId."
+          },
+          "response": []
+        },
+        {
+          "name": "CREAR EVENTO VINCULADO A TAREA",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"date\": \"2026-05-22\",\n  \"title\": \"Fecha límite PRUEBA 1\",\n  \"tipo\": \"estudiante\",\n  \"studentId\": 3,\n  \"taskId\": 1,\n  \"color\": \"#0ea5e9\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/calendar",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "calendar"
+              ]
+            },
+            "description": "Evento con referencia a una tarea. El popover del calendario mostrará el título y estado de la tarea, y un botón 'Ver tarea'.\n\ntaskId es opcional — si la tarea se elimina, el evento queda sin tarea (FK ON DELETE SET NULL)."
+          },
+          "response": []
+        },
+        {
+          "name": "ELIMINAR EVENTO",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/calendar/1",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "calendar",
+                "1"
+              ]
+            },
+            "description": "Elimina un evento por ID.\nSolo puede eliminarlo el usuario que lo creó (campo instructor_id).\nEsto aplica tanto para el instructor como para el usuario que creó un evento propio.\n\n404 si el evento no existe o no pertenece al usuario autenticado."
+          },
+          "response": []
+        }
+      ],
+      "description": "Eventos del calendario del instructor y del usuario.\n\nFlujo:\n1. Instructor crea evento (propio o para estudiante)\n2. GET /calendar/usuario devuelve al estudiante los eventos que el instructor le asignó + sus propios recordatorios\n3. Instructor puede eliminar cualquier evento que él creó\n4. Usuario solo puede eliminar sus propios recordatorios (instructor_id = userId del token)"
+    },
+    {
+      "name": "NOTAS PERSONALES",
+      "item": [
+        {
+          "name": "OBTENER NOTAS DEL USUARIO",
+          "request": {
+            "method": "GET",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/notes",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "notes"
+              ]
+            },
+            "description": "Devuelve todas las notas personales del usuario autenticado.\nOrdenadas por created_at ASC.\n\nAntes de esta milestone las notas se guardaban en localStorage del navegador y se perdían al cambiar de dispositivo o limpiar el navegador."
+          },
+          "response": []
+        },
+        {
+          "name": "CREAR NOTA",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"texto\": \"Revisar el módulo 4 antes del jueves\",\n  \"color\": \"#fef3c7\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/notes",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "notes"
+              ]
+            },
+            "description": "Crea una nota personal.\ncolor valores válidos (pastel):\n  #fef3c7 → amarillo\n  #fce7f3 → rosa\n  #d1fae5 → verde\n  #dbeafe → celeste\n\n400 si texto está vacío."
+          },
+          "response": []
+        },
+        {
+          "name": "CREAR NOTA — SIN COLOR (usa default)",
+          "request": {
+            "method": "POST",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "body": {
+              "mode": "raw",
+              "raw": "{\n  \"texto\": \"Estudiar para el examen del módulo 2\"\n}",
+              "options": {
+                "raw": {
+                  "language": "json"
+                }
+              }
+            },
+            "url": {
+              "raw": "{{URL_API}}/notes",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "notes"
+              ]
+            },
+            "description": "Prueba que el color por defecto (#fef3c7 amarillo) se aplica cuando no se envía color.\n\nVerificar en BD que color = '#fef3c7'."
+          },
+          "response": []
+        },
+        {
+          "name": "ELIMINAR NOTA",
+          "request": {
+            "method": "DELETE",
+            "header": [
+              {
+                "key": "Authorization",
+                "value": "Bearer {{ACCESS_TOKEN}}",
+                "type": "text"
+              }
+            ],
+            "url": {
+              "raw": "{{URL_API}}/notes/1",
+              "host": [
+                "{{URL_API}}"
+              ],
+              "path": [
+                "notes",
+                "1"
+              ]
+            },
+            "description": "Elimina una nota por ID.\nSolo puede eliminarla el dueño (user_id del token debe coincidir con user_id de la nota).\n\n404 si la nota no existe o no pertenece al usuario autenticado."
+          },
+          "response": []
+        }
+      ],
+      "description": "Notas personales del usuario. Migradas de localStorage al servidor en esta milestone.\n\nCada nota tiene texto libre y un color pastel elegido por el usuario.\nSe eliminan automáticamente si se elimina el usuario (FK CASCADE)."
     },
     {
       "name": "MENSAJE DE BIENVENIDA",

--- a/schemas/task.schema.js
+++ b/schemas/task.schema.js
@@ -11,8 +11,12 @@
 //   Se agrega "pendiente_aprobacion" como cuarto estado válido del sistema.
 //   Lo pone el usuario cuando considera que terminó su tarea y necesita
 //   que el admin la revise antes de marcarla como completada.
-//   Los cuatro estados siguen el flujo de trabajo del proyecto:
-//     pendiente → en_progreso → pendiente_aprobacion → completada
+//
+// ACTUALIZACIÓN v3.3.0:
+//   Se agrega "reprobada" como quinto estado válido del sistema.
+//   Lo asigna automáticamente el sistema cuando el instructor califica
+//   una tarea con nota menor a 70. El flujo completo es:
+//     pendiente → en_progreso → pendiente_aprobacion → completada | reprobada
 
 import { z } from 'zod';
 
@@ -23,6 +27,7 @@ const ESTADOS_VALIDOS = [
     'en_progreso',
     'pendiente_aprobacion',
     'completada',
+    'reprobada',   // asignado automáticamente cuando la nota es < 70
 ];
 
 // Esquema para CREAR una tarea — POST /api/tasks
@@ -46,14 +51,14 @@ export const createTaskSchema = z.object({
         .max(500, 'La descripción no puede exceder los 500 caracteres')
         .optional(),
 
-    // status: obligatorio, solo acepta los cuatro valores del sistema
-    // ACTUALIZACIÓN: se agrega "pendiente_aprobacion" como cuarto estado
+    // status: obligatorio, solo acepta los cinco valores del sistema
+    // ACTUALIZACIÓN: se agrega "reprobada" como quinto estado
     status: z.enum(
         ESTADOS_VALIDOS,
         {
             required_error:     'El estado de la tarea es obligatorio',
             invalid_type_error: 'El estado debe ser una cadena de texto',
-            message:            "El estado debe ser: 'pendiente', 'en_progreso', 'pendiente_aprobacion' o 'completada'",
+            message:            "El estado debe ser: 'pendiente', 'en_progreso', 'pendiente_aprobacion', 'completada' o 'reprobada'",
         }
     ),
 
@@ -74,6 +79,19 @@ export const createTaskSchema = z.object({
         .string({ invalid_type_error: 'El comentario debe ser una cadena de texto' })
         .max(500, 'El comentario no puede exceder los 500 caracteres')
         .optional(),
+
+    // grade: nota numérica del instructor (0-100) — opcional, solo instructores
+    grade: z
+        .number({ invalid_type_error: 'La nota debe ser un número' })
+        .min(0,   'La nota mínima es 0')
+        .max(100, 'La nota máxima es 100')
+        .nullable()
+        .optional(),
+
+    // gradeReason: motivo de la edición de nota — requerido cuando se envía grade
+    gradeReason: z
+        .string({ invalid_type_error: 'El motivo debe ser una cadena de texto' })
+        .optional(),
 });
 
 // Esquema para ACTUALIZAR una tarea completa — PUT /api/tasks/:id
@@ -81,14 +99,14 @@ export const createTaskSchema = z.object({
 export const updateTaskSchema = createTaskSchema.partial();
 
 // Esquema para CAMBIAR solo el estado — PATCH /api/tasks/:id/status
-// Solo acepta el campo status con los cuatro valores válidos del sistema
-// ACTUALIZACIÓN: se agrega "pendiente_aprobacion" al enum
+// Solo acepta el campo status con los cinco valores válidos del sistema
+// ACTUALIZACIÓN: se agrega "reprobada" al enum
 export const updateTaskStatusSchema = z.object({
     status: z.enum(
         ESTADOS_VALIDOS,
         {
             required_error: 'El estado es obligatorio',
-            message:        "El estado debe ser: 'pendiente', 'en_progreso', 'pendiente_aprobacion' o 'completada'",
+            message:        "El estado debe ser: 'pendiente', 'en_progreso', 'pendiente_aprobacion', 'completada' o 'reprobada'",
         }
     ),
 });

--- a/src/app.js
+++ b/src/app.js
@@ -12,6 +12,8 @@ import authRouter from './routes/auth.routes.js';
 import { verifyToken } from './middlewares/auth.middleware.js';
 import usersRouter from './routes/users.routes.js';
 import tasksRouter from './routes/tasks.routes.js';
+import calendarRouter from './routes/calendar.routes.js';
+import notesRouter from './routes/notes.routes.js';
 
 const app = express();
 
@@ -40,6 +42,8 @@ app.use('/api/auth', authRouter);
 // Rutas protegidas — verifyToken valida el JWT antes de llegar al controlador
 app.use('/api/users', verifyToken, usersRouter);
 app.use('/api/tasks', verifyToken, tasksRouter);
+app.use('/api/calendar', verifyToken, calendarRouter);
+app.use('/api/notes', verifyToken, notesRouter);
 
 // Middleware global de errores — debe registrarse DESPUÉS de todas las rutas
 // Si se registra antes, los errores de las rutas no llegarán aquí

--- a/src/controller/calendar.controller.js
+++ b/src/controller/calendar.controller.js
@@ -1,0 +1,89 @@
+// MÓDULO: controller/calendar.controller.js
+// CAPA: Controlador (recibe HTTP, llama el modelo, responde HTTP)
+//
+// Responsabilidad única: manejar las peticiones HTTP del calendario.
+// NUNCA maneja datos directamente — solo recibe req, llama el modelo y responde res.
+//
+// ENDPOINTS:
+//   GET    /api/calendar/instructor  → getEventosInstructor (instructor autenticado)
+//   GET    /api/calendar/usuario     → getEventosUsuario    (usuario autenticado)
+//   POST   /api/calendar             → crearEvento          (solo instructor)
+//   DELETE /api/calendar/:id         → eliminarEvento       (solo instructor propietario)
+
+import { catchAsync }                     from '../utils/catchAsync.js';
+import { successResponse, errorResponse } from '../utils/response.util.js';
+
+import {
+    getEventosInstructor as fetchEventosInstructor,
+    getEventosUsuario    as fetchEventosUsuario,
+    createEvento         as insertEvento,
+    deleteEvento         as removeEvento,
+} from '../models/calendar.model.js';
+
+// GET /api/calendar/instructor
+// Devuelve todos los eventos creados por el instructor autenticado.
+// req.usuario es adjuntado por verifyToken (auth.middleware.js).
+export const getEventosInstructor = catchAsync(async (req, res) => {
+    const instructorId = req.usuario.id;
+    const eventos = await fetchEventosInstructor(instructorId);
+    return successResponse(res, 'Eventos del instructor obtenidos', eventos);
+});
+
+// GET /api/calendar/usuario
+// Devuelve todos los eventos asignados al usuario autenticado (estudiante).
+export const getEventosUsuario = catchAsync(async (req, res) => {
+    const studentId = req.usuario.id;
+    const eventos = await fetchEventosUsuario(studentId);
+    return successResponse(res, 'Eventos del estudiante obtenidos', eventos);
+});
+
+// POST /api/calendar
+// Crea un evento nuevo.
+// Body esperado: { date, title, tipo, studentId?, taskId?, color? }
+//   tipo: 'propio' (sin estudiante) | 'estudiante' (asignado a un estudiante)
+export const crearEvento = catchAsync(async (req, res) => {
+    const instructorId = req.usuario.id;
+    const { date, title, tipo, studentId, taskId, color } = req.body;
+
+    // Validaciones básicas
+    if (!date || !title || !tipo) {
+        return errorResponse(res, 'Los campos date, title y tipo son obligatorios', 400);
+    }
+    if (tipo === 'estudiante' && !studentId) {
+        return errorResponse(res, 'Para eventos de tipo estudiante, studentId es obligatorio', 400);
+    }
+    if (!['propio', 'estudiante'].includes(tipo)) {
+        return errorResponse(res, "El tipo debe ser 'propio' o 'estudiante'", 400);
+    }
+
+    const nuevoEvento = await insertEvento({
+        instructorId,
+        studentId: tipo === 'estudiante' ? studentId : null,
+        taskId:    taskId || null,
+        date,
+        title,
+        color:     color || (tipo === 'propio' ? '#6366f1' : '#0ea5e9'),
+        tipo,
+    });
+
+    return successResponse(res, 'Evento creado correctamente', nuevoEvento, 201);
+});
+
+// DELETE /api/calendar/:id
+// Elimina un evento. Solo el instructor que lo creó puede borrarlo.
+export const eliminarEvento = catchAsync(async (req, res) => {
+    const { id }       = req.params;
+    const instructorId = req.usuario.id;
+
+    const eliminado = await removeEvento(id, instructorId);
+
+    if (!eliminado) {
+        return errorResponse(
+            res,
+            'Evento no encontrado o no tienes permiso para eliminarlo',
+            404
+        );
+    }
+
+    return successResponse(res, 'Evento eliminado correctamente', null);
+});

--- a/src/controller/notes.controller.js
+++ b/src/controller/notes.controller.js
@@ -1,0 +1,37 @@
+// MÓDULO: controller/notes.controller.js
+// CAPA: Controlador
+//
+// Endpoints:
+//   GET    /api/notes        → obtenerNotas
+//   POST   /api/notes        → crearNota
+//   DELETE /api/notes/:id    → eliminarNota
+
+import { catchAsync }                     from '../utils/catchAsync.js';
+import { successResponse, errorResponse } from '../utils/response.util.js';
+import { getNotas, createNota, deleteNota } from '../models/notes.model.js';
+
+// GET /api/notes — devuelve las notas del usuario autenticado
+export const obtenerNotas = catchAsync(async (req, res) => {
+    const notas = await getNotas(req.usuario.id);
+    return successResponse(res, 'Notas obtenidas', notas);
+});
+
+// POST /api/notes — crea una nota nueva
+// Body: { texto, color? }
+export const crearNota = catchAsync(async (req, res) => {
+    const { texto, color } = req.body;
+    if (!texto || texto.trim() === '') {
+        return errorResponse(res, 'El texto de la nota es obligatorio', 400);
+    }
+    const nota = await createNota(req.usuario.id, texto.trim(), color);
+    return successResponse(res, 'Nota creada', nota, 201);
+});
+
+// DELETE /api/notes/:id — elimina una nota del usuario autenticado
+export const eliminarNota = catchAsync(async (req, res) => {
+    const eliminada = await deleteNota(req.params.id, req.usuario.id);
+    if (!eliminada) {
+        return errorResponse(res, 'Nota no encontrada o sin permiso', 404);
+    }
+    return successResponse(res, 'Nota eliminada', null);
+});

--- a/src/controller/tasks.controller.js
+++ b/src/controller/tasks.controller.js
@@ -176,17 +176,20 @@ export const getDashboard = catchAsync(async (req, res) => {
     // Se filtra cada estado para obtener su contador individual
     const pendientes  = tareas.filter(t => t.status === 'pendiente').length;
     const enProgreso  = tareas.filter(t => t.status === 'en_progreso').length;
-    // Cuarto estado: el usuario indica que terminó y espera revisión del admin
+    // Cuarto estado: el usuario indica que terminó y espera revisión del instructor
     const aprobacion  = tareas.filter(t => t.status === 'pendiente_aprobacion').length;
     const completadas = tareas.filter(t => t.status === 'completada').length;
+    // Quinto estado: tarea reprobada por nota < 70
+    const reprobadas  = tareas.filter(t => t.status === 'reprobada').length;
 
     const estadisticas = {
         total: tareas.length,
         pendientes,
         enProgreso,
-        // La propiedad "aprobacion" la lee cargarDashboard() en el frontend
         aprobacion,
         completadas,
+        // reprobadas: tareas calificadas con nota < 70 por el instructor
+        reprobadas,
     };
 
     return successResponse(

--- a/src/controller/users.controller.js
+++ b/src/controller/users.controller.js
@@ -28,7 +28,7 @@ import {
     reactivateUser      as enableUser,      // marca is_active = 1 en la BD
 } from '../models/user.model.js';
 
-import { getTasksByUserId } from '../models/task.model.js';
+import { getTasksByUserId, registrarNombreUsuarioEliminado } from '../models/task.model.js';
 
 import bcrypt from 'bcryptjs';
 import { updateUserPassword } from '../models/user.model.js';
@@ -81,18 +81,32 @@ export const updateUser = catchAsync(async (req, res) => {
 });
 
 // DELETE /api/users/:id
-// Elimina un usuario y retorna confirmación
+// Borrado suave: marca el usuario como inactivo (is_active = 0) en vez de eliminarlo físicamente.
+// Preserva todos los datos históricos y la integridad referencial en las tareas.
+// Para eliminación permanente, usar DELETE /api/users/:id/force (solo emergencias).
 export const deleteUser = catchAsync(async (req, res) => {
-    const { id }           = req.params;
-    const usuarioEliminado = await removeUser(id);
+    const { id } = req.params;
 
-    if (!usuarioEliminado) {
+    // Verificar que el usuario existe
+    const usuario = await findUserById(id);
+    if (!usuario) {
         return errorResponse(res, `Usuario con id ${id} no encontrado`, 404);
+    }
+
+    // Si ya está inactivo, no hacer nada innecesario
+    if (usuario.is_active === 0 || usuario.is_active === false) {
+        return errorResponse(res, `El usuario "${usuario.name}" ya está desactivado`, 400);
+    }
+
+    // Borrado suave: desactivar en lugar de eliminar
+    const usuarioDesactivado = await disableUser(id);
+    if (!usuarioDesactivado) {
+        return errorResponse(res, 'Error al desactivar el usuario', 500);
     }
 
     return successResponse(
         res,
-        `Usuario "${usuarioEliminado.name}" eliminado correctamente`
+        `Usuario "${usuarioDesactivado.name}" desactivado correctamente (borrado suave)`
     );
 });
 
@@ -291,5 +305,46 @@ export const reactivateUser = catchAsync(async (req, res) => {
         res,
         `Usuario "${usuarioReactivado.name}" reactivado correctamente`,
         usuarioReactivado
+    );
+});
+// ── ELIMINAR USUARIO FORZOSAMENTE ─────────────────────────────────────────────
+// DELETE /api/users/:id/force
+// Elimina un usuario sin importar su estado (activo/inactivo) ni tareas pendientes.
+// Solo el admin puede ejecutar esta acción (requireAdmin en la ruta).
+// Se requiere un motivo (reason) en el body para auditoría.
+//
+// Diferencias con DELETE /api/users/:id:
+//   - No verifica is_active — elimina activo o inactivo
+//   - No verifica tareas pendientes — elimina aunque tenga tareas
+//   - Requiere body { reason } como campo obligatorio de auditoría
+export const forceDeleteUser = catchAsync(async (req, res) => {
+    const { id } = req.params;
+    const { reason } = req.body;
+
+    // Validar que se envió un motivo — es obligatorio para auditoría
+    if (!reason || String(reason).trim().length < 10) {
+        return errorResponse(
+            res,
+            'El motivo de eliminación es obligatorio y debe tener al menos 10 caracteres',
+            400
+        );
+    }
+
+    // Verificar que el usuario existe
+    const usuario = await findUserById(id);
+    if (!usuario) {
+        return errorResponse(res, `Usuario con id ${id} no encontrado`, 404);
+    }
+
+    // BORRADO SUAVE PREVIO: guardar el nombre del usuario en todas las tareas
+    // que lo tienen asignado, para que sigan mostrando su nombre aunque ya no esté en la BD
+    await registrarNombreUsuarioEliminado(Number(id), usuario.name);
+
+    // Eliminar sin validaciones adicionales — cierre forzoso
+    await removeUser(id);
+
+    return successResponse(
+        res,
+        `Usuario "${usuario.name}" eliminado forzosamente. Motivo: ${reason.trim()}`
     );
 });

--- a/src/models/calendar.model.js
+++ b/src/models/calendar.model.js
@@ -1,0 +1,143 @@
+// MÓDULO: models/calendar.model.js
+// CAPA: Modelo (datos y operaciones sobre la tabla calendar_events en MySQL)
+//
+// Responsabilidad única: interactuar con la tabla calendar_events.
+// NUNCA conoce req, res ni Express.
+//
+// ENDPOINTS que usa este modelo:
+//   GET  /api/calendar/instructor     → getEventosInstructor
+//   GET  /api/calendar/usuario        → getEventosUsuario
+//   POST /api/calendar                → createEvento
+//   DELETE /api/calendar/:id          → deleteEvento
+
+import pool from '../database/db.connection.js';
+
+// formatearEvento — convierte una fila raw de MySQL a objeto camelCase
+function formatearEvento(fila) {
+    if (!fila) return null;
+    return {
+        id:            fila.id,
+        instructorId:  fila.instructor_id,
+        studentId:     fila.student_id    || null,
+        taskId:        fila.task_id       || null,
+        date:          fila.date instanceof Date
+                           ? fila.date.toISOString().split('T')[0]
+                           : fila.date,
+        title:         fila.title,
+        color:         fila.color,
+        tipo:          fila.tipo,
+        // Datos del estudiante asignado (JOIN con users)
+        studentName:   fila.student_name  || null,
+        // Datos de la tarea relacionada (JOIN con tasks)
+        taskTitle:     fila.task_title    || null,
+        taskStatus:    fila.task_status   || null,
+    };
+}
+
+// ── OBTENER EVENTOS DEL INSTRUCTOR ─────────────────────────────────────────
+// Devuelve todos los eventos creados por el instructor dado.
+// Incluye nombre del estudiante y datos de tarea (si existen) via JOIN.
+// Parámetro: instructorId — id del instructor autenticado
+export async function getEventosInstructor(instructorId) {
+    const sql = `
+        SELECT
+            ce.id,
+            ce.instructor_id,
+            ce.student_id,
+            ce.task_id,
+            ce.date,
+            ce.title,
+            ce.color,
+            ce.tipo,
+            u.name  AS student_name,
+            t.title AS task_title,
+            t.status AS task_status
+        FROM calendar_events ce
+        LEFT JOIN users  u ON u.id = ce.student_id
+        LEFT JOIN tasks  t ON t.id = ce.task_id
+        WHERE ce.instructor_id = ?
+        ORDER BY ce.date ASC, ce.id ASC
+    `;
+    const [rows] = await pool.query(sql, [instructorId]);
+    return rows.map(formatearEvento);
+}
+
+// ── OBTENER EVENTOS DEL USUARIO (ESTUDIANTE) ───────────────────────────────
+// Devuelve todos los eventos que el instructor asignó a este estudiante.
+// El estudiante ve estos eventos en su propio calendario (solo lectura).
+// Parámetro: studentId — id del usuario/estudiante autenticado
+export async function getEventosUsuario(studentId) {
+    // Devuelve:
+    //   1. Eventos asignados al usuario por el instructor (student_id = userId)
+    //   2. Eventos propios creados por el usuario mismo (instructor_id = userId, tipo = 'propio')
+    const sql = `
+        SELECT
+            ce.id,
+            ce.instructor_id,
+            ce.student_id,
+            ce.task_id,
+            ce.date,
+            ce.title,
+            ce.color,
+            ce.tipo,
+            u.name  AS student_name,
+            t.title AS task_title,
+            t.status AS task_status
+        FROM calendar_events ce
+        LEFT JOIN users  u ON u.id = ce.student_id
+        LEFT JOIN tasks  t ON t.id = ce.task_id
+        WHERE ce.student_id = ?
+           OR (ce.instructor_id = ? AND ce.tipo = 'propio')
+        ORDER BY ce.date ASC, ce.id ASC
+    `;
+    const [rows] = await pool.query(sql, [studentId, studentId]);
+    return rows.map(formatearEvento);
+}
+
+// ── CREAR EVENTO ────────────────────────────────────────────────────────────
+// Inserta un evento nuevo en la tabla.
+// Parámetro: datos — { instructorId, studentId, taskId, date, title, color, tipo }
+export async function createEvento(datos) {
+    const { instructorId, studentId, taskId, date, title, color, tipo } = datos;
+
+    const sql = `
+        INSERT INTO calendar_events
+            (instructor_id, student_id, task_id, date, title, color, tipo)
+        VALUES (?, ?, ?, ?, ?, ?, ?)
+    `;
+    const [result] = await pool.query(sql, [
+        instructorId,
+        studentId || null,
+        taskId    || null,
+        date,
+        title,
+        color     || '#3b82f6',
+        tipo      || 'propio',
+    ]);
+
+    // Retornar el evento recién creado (con JOIN para incluir nombres)
+    const [rows] = await pool.query(
+        `SELECT ce.*, u.name AS student_name, t.title AS task_title, t.status AS task_status
+         FROM calendar_events ce
+         LEFT JOIN users u ON u.id = ce.student_id
+         LEFT JOIN tasks t ON t.id = ce.task_id
+         WHERE ce.id = ?`,
+        [result.insertId]
+    );
+    return formatearEvento(rows[0]);
+}
+
+// ── ELIMINAR EVENTO ─────────────────────────────────────────────────────────
+// Elimina un evento por id. Solo el instructor que lo creó puede borrarlo.
+// Parámetro: id           — id del evento a eliminar
+// Parámetro: instructorId — id del instructor autenticado (verificación de propiedad)
+// Retorna: true si se eliminó, false si no existía o no pertenecía al instructor
+// userId puede ser instructor o el propio usuario que creó el evento
+export async function deleteEvento(id, userId) {
+    const sql = `
+        DELETE FROM calendar_events
+        WHERE id = ? AND instructor_id = ?
+    `;
+    const [result] = await pool.query(sql, [id, userId]);
+    return result.affectedRows > 0;
+}

--- a/src/models/notes.model.js
+++ b/src/models/notes.model.js
@@ -1,0 +1,41 @@
+// MÓDULO: models/notes.model.js
+// CAPA: Modelo — operaciones sobre la tabla user_notes
+//
+// Endpoints:
+//   GET    /api/notes        → getNotas(userId)
+//   POST   /api/notes        → createNota(userId, texto, color)
+//   DELETE /api/notes/:id    → deleteNota(id, userId)
+
+import pool from '../database/db.connection.js';
+
+// getNotas — devuelve todas las notas del usuario ordenadas por fecha
+export async function getNotas(userId) {
+    const [rows] = await pool.query(
+        'SELECT id, texto, color, created_at FROM user_notes WHERE user_id = ? ORDER BY created_at ASC',
+        [userId]
+    );
+    return rows.map(r => ({ id: r.id, texto: r.texto, color: r.color }));
+}
+
+// createNota — inserta una nota nueva y retorna el objeto creado
+export async function createNota(userId, texto, color) {
+    const [result] = await pool.query(
+        'INSERT INTO user_notes (user_id, texto, color) VALUES (?, ?, ?)',
+        [userId, texto, color || '#fef3c7']
+    );
+    const [rows] = await pool.query(
+        'SELECT id, texto, color FROM user_notes WHERE id = ?',
+        [result.insertId]
+    );
+    return rows[0] ? { id: rows[0].id, texto: rows[0].texto, color: rows[0].color } : null;
+}
+
+// deleteNota — elimina una nota. Solo el dueño puede borrarla.
+// Retorna true si se eliminó, false si no existía o no pertenece al usuario.
+export async function deleteNota(id, userId) {
+    const [result] = await pool.query(
+        'DELETE FROM user_notes WHERE id = ? AND user_id = ?',
+        [id, userId]
+    );
+    return result.affectedRows > 0;
+}

--- a/src/models/task.model.js
+++ b/src/models/task.model.js
@@ -55,23 +55,32 @@ function deserializarUsuarios(valor) {
 //
 // Parámetro: filaDb — objeto raw devuelto por pool.query (nombres con underscore)
 // Retorna: objeto con nombres camelCase listo para enviar como JSON al frontend
+// parsearDeletedUserNames — convierte el campo deleted_user_names de MySQL a objeto JS
+// Necesario porque mysql2 puede devolver el JSON como string o como objeto según la versión
+// Retorna {} si el campo es null, undefined o no se puede parsear
+function parsearDeletedUserNames(valor) {
+    if (!valor) return {};
+    if (typeof valor === 'object') return valor;
+    try { return JSON.parse(valor); } catch { return {}; }
+}
+
 function formatearTarea(filaDb) {
-    // Si filaDb es undefined (tarea no encontrada), retornar null en lugar de crashear
     if (!filaDb) return null;
     return {
-        // Campos que no necesitan transformación de nombre
-        id:            filaDb.id,
-        title:         filaDb.title,
-        description:   filaDb.description,
-        status:        filaDb.status,
-        // comment: usa || null para convertir undefined a null de forma explícita
-        // Si la columna es NULL en MySQL, mysql2 lo devuelve como null de JS
-        comment:       filaDb.comment || null,
-        // assigned_users (snake_case de MySQL) → assignedUsers (camelCase del frontend)
-        // deserializarUsuarios convierte el JSON string '[1,2,3]' al arreglo [1,2,3]
-        assignedUsers: deserializarUsuarios(filaDb.assigned_users),
-        // created_ud (nombre de columna en la BD) → createdAt (camelCase del frontend)
-        createdAt:     filaDb.created_ud
+        id:               filaDb.id,
+        title:            filaDb.title,
+        description:      filaDb.description,
+        status:           filaDb.status,
+        comment:          filaDb.comment || null,
+        // grade: nota numérica (0-100) asignada por el instructor. null = sin calificar
+        grade:            filaDb.grade != null ? Number(filaDb.grade) : null,
+        // gradeReason: motivo de la última edición de nota por el instructor
+        gradeReason:      filaDb.grade_reason || null,
+        assignedUsers:    deserializarUsuarios(filaDb.assigned_users),
+        // deletedUserNames: mapa { "userId": "nombre" } de usuarios eliminados permanentemente
+        // Se rellena antes del hard delete para preservar el nombre aunque ya no esté en users
+        deletedUserNames: parsearDeletedUserNames(filaDb.deleted_user_names),
+        createdAt:        filaDb.created_ud
     };
 }
 
@@ -86,7 +95,7 @@ export async function getAllTasks() {
     const [rows]     = await pool.query('SELECT * FROM tasks');
     // Query 2: obtener id, name y documento de todos los usuarios para resolver los IDs
     // Solo se traen los campos necesarios, no todo el objeto usuario (evita exponer passwords)
-    const [usuarios] = await pool.query('SELECT id, name, documento FROM users');
+    const [usuarios] = await pool.query('SELECT id, name, documento, is_active FROM users');
 
     // Para cada tarea, resolver los IDs de usuarios asignados a nombres legibles
     return rows.map(function(fila) {
@@ -95,12 +104,15 @@ export async function getAllTasks() {
 
         // Resolver cada ID del arreglo assignedUsers al nombre del usuario correspondiente
         const nombres = tarea.assignedUsers.map(function(id) {
-            // find busca en el arreglo de usuarios el que tiene ese id
             const encontrado = usuarios.find(u => u.id === Number(id));
-            // Si el usuario existe retornar su nombre, si fue eliminado retornar null
-            return encontrado ? encontrado.name : null;
-        // filter(Boolean) elimina los null del arreglo (usuarios que ya no existen)
-        }).filter(Boolean);
+            if (!encontrado) {
+                // Buscar en el mapa de nombres de usuarios eliminados permanentemente
+                const nombreGuardado = tarea.deletedUserNames[String(id)];
+                return nombreGuardado ? `${nombreGuardado} (eliminado)` : `[Usuario eliminado]`;
+            }
+            if (encontrado.is_active === 0) return `${encontrado.name} (inactivo)`;
+            return encontrado.name;
+        });
 
         // assignedUsersDisplay: string con los nombres separados por coma
         // Si no hay usuarios asignados, null (el frontend muestra '—')
@@ -126,8 +138,28 @@ export async function getTaskById(id) {
         'SELECT * FROM tasks WHERE id = ?',
         [Number(id)]
     );
-    // formatearTarea retorna null si rows[0] es undefined (tarea no encontrada)
-    return formatearTarea(rows[0]);
+    if (!rows[0]) return null;
+
+    const tarea = formatearTarea(rows[0]);
+
+    // Resolver assignedUsersDisplay igual que getAllTasks
+    // Sin esto, GET /api/tasks/:id devuelve los IDs pero no los nombres
+    const [usuarios] = await pool.query('SELECT id, name, documento, is_active FROM users');
+    const nombres = tarea.assignedUsers.map(function(uid) {
+        const u = usuarios.find(u => u.id === Number(uid));
+        if (!u) {
+            const guardado = tarea.deletedUserNames[String(uid)];
+            return guardado ? `${guardado} (eliminado)` : '[Usuario eliminado]';
+        }
+        return u.is_active === 0 ? `${u.name} (inactivo)` : u.name;
+    });
+    tarea.assignedUsersDisplay = nombres.length > 0 ? nombres.join(', ') : null;
+    tarea.assignedDocumentos   = tarea.assignedUsers.map(function(uid) {
+        const u = usuarios.find(u => u.id === Number(uid));
+        return u ? u.documento.toString() : null;
+    }).filter(Boolean);
+
+    return tarea;
 }
 
 // createTask — inserta una tarea nueva en la tabla tasks
@@ -150,17 +182,15 @@ export async function createTask({
 }) {
     // INSERT con los 5 campos — el orden de los ? debe coincidir con VALUES
     const [result] = await pool.query(
-        'INSERT INTO tasks (title, description, status, assigned_users, comment) VALUES (?, ?, ?, ?, ?)',
+        'INSERT INTO tasks (title, description, status, assigned_users, comment, grade, grade_reason) VALUES (?, ?, ?, ?, ?, ?, ?)',
         [
             title,
-            // Si description no viene o es cadena vacía, guardar cadena vacía en MySQL
             description || '',
             status,
-            // serializarUsuarios convierte [1,2,3] a '[1,2,3]' para guardar como JSON en MySQL
             serializarUsuarios(assignedUsers),
-            // Si comment es cadena vacía lo convertimos a null para consistencia en la BD
-            // Una cadena vacía y null son equivalentes semánticamente en este contexto
-            comment || null
+            comment || null,
+            null,   // grade empieza null — se asigna cuando el instructor califica
+            null    // grade_reason empieza null
         ]
     );
     // result.insertId contiene el id AUTO_INCREMENT que MySQL asignó a la nueva fila
@@ -191,8 +221,11 @@ export async function updateTask(id, campos) {
     // serializarUsuarios convierte el arreglo JS al JSON string que guarda MySQL
     if (campos.assignedUsers !== undefined) camposDb.assigned_users = serializarUsuarios(campos.assignedUsers);
     // CORRECCIÓN: se permite actualizar el campo comment
-    // Se convierte cadena vacía a null para que MySQL guarde NULL, no una cadena vacía
     if (campos.comment !== undefined) camposDb.comment = campos.comment || null;
+    // grade: nota numérica del instructor (0-100) — null significa sin calificar
+    if (campos.grade !== undefined) camposDb.grade = (campos.grade !== null && campos.grade !== '') ? Number(campos.grade) : null;
+    // grade_reason: motivo de la última edición de nota — obligatorio cuando se edita grade
+    if (campos.gradeReason !== undefined) camposDb.grade_reason = campos.gradeReason || null;
 
     // Si no llegó ningún campo válido, no ejecutar el UPDATE innecesariamente
     // Retornar la tarea sin cambios
@@ -290,4 +323,42 @@ export async function removeUserFromTask(taskId, userId) {
 
     // Actualizar la tarea con el arreglo sin el usuario eliminado
     return updateTask(taskId, { assignedUsers: filtrados });
+}
+// registrarNombreUsuarioEliminado — guarda el nombre de un usuario en deleted_user_names
+// de TODAS las tareas que lo tienen asignado, antes de eliminarlo permanentemente.
+// Se llama desde forceDeleteUser en users.controller.js justo antes del DELETE.
+//
+// Parámetro: userId — id del usuario que se va a eliminar
+// Parámetro: userName — nombre del usuario a preservar
+// Retorna: número de tareas actualizadas
+export async function registrarNombreUsuarioEliminado(userId, userName) {
+    // Buscar todas las tareas que tienen este userId en su assigned_users JSON
+    const [rows] = await pool.query(
+        `SELECT id, deleted_user_names FROM tasks
+         WHERE JSON_CONTAINS(assigned_users, CAST(? AS JSON), '$')`,
+        [Number(userId)]
+    );
+
+    if (rows.length === 0) return 0;
+
+    // Para cada tarea, agregar la entrada { "userId": "nombre" } al mapa
+    for (const fila of rows) {
+        let mapa = {};
+        try {
+            if (fila.deleted_user_names) {
+                mapa = typeof fila.deleted_user_names === 'object'
+                    ? fila.deleted_user_names
+                    : JSON.parse(fila.deleted_user_names);
+            }
+        } catch { mapa = {}; }
+
+        mapa[String(userId)] = userName;
+
+        await pool.query(
+            'UPDATE tasks SET deleted_user_names = ? WHERE id = ?',
+            [JSON.stringify(mapa), fila.id]
+        );
+    }
+
+    return rows.length;
 }

--- a/src/routes/calendar.routes.js
+++ b/src/routes/calendar.routes.js
@@ -1,0 +1,43 @@
+// MÓDULO: routes/calendar.routes.js
+// CAPA: Rutas (conecta URLs con controladores)
+//
+// REGLA CRÍTICA DE ORDEN:
+//   Las rutas /instructor y /usuario deben ir ANTES de /:id
+//   para que Express no las capture como parámetros dinámicos.
+//
+// MONTAJE EN app.js:
+//   import calendarRouter from './routes/calendar.routes.js';
+//   app.use('/api/calendar', verifyToken, calendarRouter);
+
+import { Router } from 'express';
+
+import {
+    getEventosInstructor,
+    getEventosUsuario,
+    crearEvento,
+    eliminarEvento,
+} from '../controller/calendar.controller.js';
+
+const router = Router();
+
+// ── RUTAS SIN PARÁMETRO DINÁMICO (van PRIMERO) ─────────────────────────────
+
+// GET /api/calendar/instructor
+// El instructor obtiene sus propios eventos (propios + para estudiantes)
+router.get('/instructor', getEventosInstructor);
+
+// GET /api/calendar/usuario
+// El usuario/estudiante obtiene los eventos que el instructor le asignó
+router.get('/usuario', getEventosUsuario);
+
+// ── CRUD ────────────────────────────────────────────────────────────────────
+
+// POST /api/calendar
+// Crea un evento nuevo (solo el instructor puede crear eventos)
+router.post('/', crearEvento);
+
+// DELETE /api/calendar/:id
+// Elimina un evento (solo el instructor que lo creó)
+router.delete('/:id', eliminarEvento);
+
+export default router;

--- a/src/routes/notes.routes.js
+++ b/src/routes/notes.routes.js
@@ -1,0 +1,16 @@
+// MÓDULO: routes/notes.routes.js
+//
+// MONTAJE EN app.js:
+//   import notesRouter from './routes/notes.routes.js';
+//   app.use('/api/notes', verifyToken, notesRouter);
+
+import { Router } from 'express';
+import { obtenerNotas, crearNota, eliminarNota } from '../controller/notes.controller.js';
+
+const router = Router();
+
+router.get('/',     obtenerNotas);   // GET    /api/notes
+router.post('/',    crearNota);      // POST   /api/notes
+router.delete('/:id', eliminarNota); // DELETE /api/notes/:id
+
+export default router;

--- a/src/routes/users.routes.js
+++ b/src/routes/users.routes.js
@@ -24,6 +24,7 @@ import {
     createUser,
     updateUser,
     deleteUser,
+    forceDeleteUser,
     getUserTasks,
     changeUserRole,          // ← nueva función
     changeUserPassword,
@@ -89,8 +90,13 @@ router.patch('/:id/deactivate',  requireAdmin, deactivateUser);
 // Reactivar usuario desactivado — solo admin, mismo patrón que deactivate
 router.patch('/:id/reactivate',  requireAdmin, reactivateUser);
 
-// DELETE /api/users/:id — elimina un usuario del sistema (no requiere validación de body)
+// DELETE /api/users/:id — elimina un usuario del sistema (requiere que esté inactivo)
 router.delete('/:id', deleteUser);
+
+// DELETE /api/users/:id/force — eliminación forzosa sin restricciones de estado ni tareas
+// Requiere body { reason } con al menos 10 caracteres para auditoría
+// Solo accesible para administradores (requireAdmin)
+router.delete('/:id/force', requireAdmin, forceDeleteUser);
 
 // PATCH /api/users/:id/role — cambia el rol de un usuario
 // verifyToken ya se aplica en app.js para todas las rutas /api/users


### PR DESCRIPTION
## Descripción del Cambio
Entrega consolidada de todos los cambios implementados en el backend del sistema de gestión de tareas académicas. Incluye el sistema completo de soft delete de usuarios (desactivar, reactivar, eliminación permanente con preservación de nombre en tareas), columnas grade y grade_reason en la tabla tasks, corrección del resolver de nombres en getTaskById, quinto estado "reprobada" en el schema de validación, y los módulos nuevos de calendario de eventos y notas personales con sus respectivas tablas, modelos, controladores y rutas protegidas por JWT.

---

## Tipo de Cambio
- [x] **feat**: Nueva funcionalidad.
- [x] **fix**: Corrección de error.
- [ ] **docs / style**: Documentación o formato.
- [ ] **refactor**: Mejora de código (sin cambios funcionales).

## Relación con Tareas
**Vínculo:** Closes #125 

---

## Checklist de Calidad Universal
- [x] **Sincronización:** he hecho `git pull origin release` antes de este PR
- [x] **Limpieza:** sin `console.log` ni comentarios de prueba en ningún archivo
- [x] **Estándares:** patrón { success, message, data } en todos los endpoints nuevos

### Validación FRONTEND (Si aplica)
- [ ] **Responsive:** Probado en resoluciones de móvil y escritorio.
- [ ] **Assets:** Las imágenes están optimizadas y en la carpeta `public/assets`.
- [ ] **Componentización:** El código se separó en componentes reutilizables (si aplica).

### Validación BACKEND (Si aplica)
- [x] El servidor arranca con `npm run dev` sin errores en la terminal
- [x] Todos los endpoints nuevos probados en Postman con token válido
- [x] Todos los endpoints nuevos devuelven 401 sin token
- [x] Las migraciones SQL ejecutadas en la BD de desarrollo sin errores

---

## Evidencia de Trabajo
> Adjuntar las siguientes capturas de Postman antes de solicitar la revisión de Karol:

### 1. DELETE /api/users/:id — soft delete
Captura mostrando la petición y la respuesta 200 con mensaje de desactivación. Luego una captura de GET /api/users confirmando que el usuario aparece con is_active: 0.
<img width="1434" height="811" alt="image" src="https://github.com/user-attachments/assets/4bbf8bed-5841-4e4d-9000-d470991cbacb" />
<img width="1411" height="738" alt="image" src="https://github.com/user-attachments/assets/ee737d01-4722-40a8-9e8b-b9f3e91e5d1d" />


### 2. PATCH /api/users/:id/deactivate — con tareas activas
Captura mostrando la respuesta 400 con mensaje claro cuando el usuario tiene tareas en estado pendiente o en_progreso.
<img width="1425" height="585" alt="image" src="https://github.com/user-attachments/assets/09283351-ec79-488e-a069-8dcd75b9ba87" />

### 3. PATCH /api/users/:id/reactivate
Captura mostrando la respuesta 200 y el usuario con is_active: 1 en la respuesta.
<img width="1434" height="831" alt="image" src="https://github.com/user-attachments/assets/839fc2b3-33a2-4f17-8237-2e0b5f10ddcf" />

### 4. DELETE /api/users/:id/force — eliminación permanente
Captura de la petición con body { reason: "..." } y la respuesta 200 con el nombre del usuario en el mensaje. Captura adicional de GET /api/users confirmando que el registro ya no existe.
<img width="1432" height="604" alt="image" src="https://github.com/user-attachments/assets/0d314f26-d1eb-4609-b4d7-32d9c94d4c85" />

### 5. DELETE /api/users/:id/force — validación de reason corto
Captura mostrando la respuesta 400 cuando reason tiene menos de 10 caracteres.
<img width="1437" height="598" alt="image" src="https://github.com/user-attachments/assets/df860267-cf35-48cd-86f5-4b254e8dd7ba" />

### 6. PUT /api/tasks/:id — con grade y gradeReason
Captura de la petición con body { grade: 85, gradeReason: "Excelente entrega" } y la respuesta mostrando grade: 85 y gradeReason en el objeto de tarea retornado.
<img width="1430" height="854" alt="image" src="https://github.com/user-attachments/assets/d0d20220-1e0e-429e-8d44-10589c222730" />

### 7. PUT /api/tasks/:id — con status reprobada
Captura de la petición con body { status: "reprobada" } y la respuesta 200 confirmando el cambio. Captura adicional con status "invalido" mostrando el 400 de Zod.
<img width="1430" height="870" alt="image" src="https://github.com/user-attachments/assets/2adf126e-a7cd-4e12-9b9e-53c98b091ffc" />

### 8. GET /api/tasks/:id — assignedUsersDisplay resuelto
Captura de la respuesta de GET /api/tasks/:id para una tarea asignada a al menos un usuario, mostrando assignedUsersDisplay como array de nombres, no de IDs.
<img width="1427" height="868" alt="image" src="https://github.com/user-attachments/assets/3f404d93-a202-4241-9773-204a02080eed" />

### 9. GET /api/calendar/instructor — eventos del instructor
Captura de la respuesta con token de un usuario instructor, mostrando el array de eventos. Puede estar vacío si no se han creado eventos aún; lo importante es el 200.
<img width="1427" height="861" alt="image" src="https://github.com/user-attachments/assets/9af6b0b7-1f9f-49a4-982d-c47b75b0b622" />

### 10. POST /api/calendar — crear evento
Captura de la petición con body { date, title, color, tipo: "propio" } y la respuesta 200 con el evento creado, incluyendo el id asignado por la BD.
<img width="1432" height="861" alt="image" src="https://github.com/user-attachments/assets/e285594f-2145-4f7b-b8cd-f78cb4cc0a21" />

### 11. GET /api/notes — notas del usuario
Captura de la respuesta con token de un usuario estudiante mostrando su lista de notas.
<img width="1434" height="861" alt="image" src="https://github.com/user-attachments/assets/cea94776-9d0d-49cd-ac00-214aee6e2ff2" />

### 12. POST /api/notes — crear nota
Captura de la petición con body { texto: "Mi primera nota", color: "#fef3c7" } y la respuesta 200 con la nota creada. El user_id en la respuesta debe coincidir con el del token, no venir del body.
<img width="1428" height="667" alt="image" src="https://github.com/user-attachments/assets/c008c22e-9982-456c-8c89-06c9a7864f73" />

### 13. DELETE /api/notes/:id —  (200)
Captura mostrando la respuesta 200 al intentar eliminar una nota con el id que corresponde al token usado en la petición.
<img width="1429" height="586" alt="image" src="https://github.com/user-attachments/assets/5e493da0-314c-466a-b09a-61c407a4383a" />

### 14. Terminal — servidor corriendo sin errores
Captura de la terminal mostrando el servidor arrancado con `npm run dev` sin ningún error o warning relacionado con los archivos nuevos.
<img width="730" height="288" alt="image" src="https://github.com/user-attachments/assets/1a46db21-7947-44f3-8fd9-1e11895b766b" />

---

## Análisis de Impacto
Los endpoints /api/calendar y /api/notes son nuevos y no afectan los endpoints ya entregados. La modificación de task.model.js (grade, getTaskById) es retrocompatible: las columnas nuevas son opcionales (NULL). El cambio en deleteUser() cambia comportamiento previo (ahora desactiva en lugar de eliminar), lo que es intencional para el soft delete.